### PR TITLE
BBD-570: Pagination can't navigate to last page on max result set

### DIFF
--- a/src/core/selectors.ts
+++ b/src/core/selectors.ts
@@ -1,3 +1,4 @@
+import { MAX_RECORDS } from './adapters/search';
 import { Request } from 'groupby-api';
 import Store from './store';
 
@@ -6,15 +7,16 @@ namespace Selectors {
   export const searchRequest = (state: Store.State): Request => {
     const sort = Selectors.sort(state);
     const pageSize = Selectors.pageSize(state);
+    const skip = Selectors.skip(state, pageSize);
 
     return <any>{
-      pageSize,
+      pageSize: Math.min(pageSize, MAX_RECORDS - skip),
       fields: Selectors.fields(state),
       query: Selectors.query(state),
       collection: Selectors.collection(state),
       refinements: Selectors.selectedRefinements(state),
       sort: sort && Selectors.requestSort(sort),
-      skip: Selectors.skip(state, pageSize)
+      skip
     };
   };
 

--- a/test/unit/core/selectors.ts
+++ b/test/unit/core/selectors.ts
@@ -1,7 +1,30 @@
+import { MAX_RECORDS } from '../../../src/core/adapters/search';
 import Selectors from '../../../src/core/selectors';
 import suite from '../_suite';
 
 suite('selectors', ({ expect, stub }) => {
+
+  describe('searchRequest()', () => {
+    it('should decrease page size to prevent exceeding MAX_RECORDS', () => {
+      const remainingRecords = 2;
+      const originalPageSize = MAX_RECORDS - 1;
+      const originalSkip = MAX_RECORDS - remainingRecords;
+
+      stub(Selectors, 'fields');
+      stub(Selectors, 'query');
+      stub(Selectors, 'collection');
+      stub(Selectors, 'selectedRefinements');
+      stub(Selectors, 'sort');
+      stub(Selectors, 'requestSort');
+      stub(Selectors, 'pageSize').returns(originalPageSize);
+      stub(Selectors, 'skip').returns(originalSkip);
+
+      const { pageSize, skip } = Selectors.searchRequest(<any>{});
+
+      expect(pageSize).to.eq(remainingRecords);
+      expect(skip).to.eq(originalSkip);
+    });
+  });
 
   describe('navigation()', () => {
     it('should select a navigation from the state', () => {


### PR DESCRIPTION
Server returns failure when the sum of pageSize and skip exceeds 10000.