### PR TITLE
fix(BBD 723): refactor UPDATE_SEARCH action to be a bulk action creator

### DIFF
--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -55,9 +55,9 @@ export function createActions(flux: FluxCapacitor) {
           if ('index' in search) {
             searchActions.push(actions.selectRefinement(search.navigationId, search.index));
           } else if (search.range) {
-            // add range
-          } else {
-            // add value
+            searchActions.push(actions.addRefinement(search.navigationId, search.low, search.high));
+          } else if ('value' in search) {
+            searchActions.push(actions.addRefinement(search.navigationId, search.value));
           }
         }
 

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -104,8 +104,11 @@ export function createActions(flux: FluxCapacitor) {
           }
         }),
 
-      switchRefinement: (field: string, valueOrLow: any, high: any = null) =>
-        actions.updateSearch({ ...refinementPayload(field, valueOrLow, high), clear: field }),
+      switchRefinement: (field: string, valueOrLow: any, high: any = null) => [
+        actions.resetPage(),
+        actions.resetRefinements(field),
+        actions.addRefinement(field, valueOrLow, high)
+      ],
 
       resetRefinements: (field?: boolean | string): Actions.ResetRefinements =>
         action(Actions.RESET_REFINEMENTS, field, {
@@ -135,11 +138,26 @@ export function createActions(flux: FluxCapacitor) {
           }
         }),
 
-      search: (query: string = Selectors.query(flux.store.getState())) =>
-        actions.updateSearch({ query, clear: true }),
+      search: (query: string = Selectors.query(flux.store.getState())) => [
+        actions.resetPage(),
+        actions.resetRefinements(true),
+        actions.updateQuery(query)
+      ],
+      // actions.updateSearch({ query, clear: true }),
+      // tslint:disable-next-line max-line-length
+      resetRecall: (query: string = null, { field: navigationId, index }: { field: string, index: number } = <any>{}) => {
+        const resetActions: any[] = [
+          actions.resetPage(),
+          actions.resetRefinements(true),
+          actions.updateQuery(query)
+        ];
+        if (navigationId) {
+          resetActions.push(actions.selectRefinement(navigationId, index));
+        }
 
-      resetRecall: (query: string = null, { field: navigationId, index }: { field: string, index: number } = <any>{}) =>
-        actions.updateSearch({ query, navigationId, index, clear: true }),
+        return resetActions;
+      },
+        // actions.updateSearch({ query, navigationId, index, clear: true }),
 
       selectRefinement: (navigationId: string, index: number): Actions.SelectRefinement =>
         action(Actions.SELECT_REFINEMENT, { navigationId, index }, {

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -52,25 +52,24 @@ export function createActions(flux: FluxCapacitor) {
         }
         // updateSearch: (search: Actions.Payload.Search): Actions.UpdateSearch => {
         // action(Actions.UPDATE_SEARCH,
-        //   'query' in search ? { ...search, query: search.query && search.query.trim() } : search,
-        //   {
-        //     ...metadata,
-        //     validator: {
-        //       payload: [{
-        //         func: ({ query }) => !('query' in search) || !!query || query === null,
-        //         msg: 'search term is empty'
-        //       }, {
-        //         func: ({ query }, state) => query !== Selectors.query(state) || query === null,
-        //         msg: 'search term is not different'
-        //       }]
-        //     }
-        //   })
+        //   'query' in search ? { ...search, query: search.query && search.query.trim() } : search)
         //
         return searchActions;
       },
 
       updateQuery: (query: string): Actions.UpdateQuery =>
-        action(Actions.UPDATE_QUERY, query, metadata),
+        action(Actions.UPDATE_QUERY, query && query.trim(), {
+          ...metadata,
+          validator: {
+            payload: [{
+              func: (_query) => !!_query || _query === null,
+              msg: 'search term is empty'
+            }, {
+              func: (_query, state) => _query !== Selectors.query(state),
+              msg: 'search term is not different'
+            }]
+          }
+        }),
 
       addRefinement: (field: string, valueOrLow: any, high: any = null) =>
         actions.updateSearch(refinementPayload(field, valueOrLow, high)),

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -49,7 +49,7 @@ export function createActions(flux: FluxCapacitor) {
           searchActions.push(...actions.updateQuery(search.query));
         }
         if ('clear' in search) {
-          searchActions.push(...actions.resetRefinements(search.clear));
+          searchActions.push(...actions.checkAndResetRefinements(search));
         }
         if ('navigationId' in search) {
           if ('index' in search) {
@@ -62,6 +62,16 @@ export function createActions(flux: FluxCapacitor) {
         }
 
         return searchActions;
+      },
+
+      checkAndResetRefinements: ({ low, high, value, navigationId, range, clear }: Actions.Payload.Search):
+      Actions.CheckAndResetRefinements => {
+        const currentRefinements = Selectors.selectedRefinements(flux.store.getState());
+        const refinement = { low, high, value };
+        // assumes only one refinement can be added at once
+        return (!navigationId || currentRefinements.length !== 1 ||
+                !SearchAdapter.refinementsMatch(<any>refinement, currentRefinements[0], range ? 'Range' : 'Value')) ?
+          actions.resetRefinements(clear) : [];
       },
 
       updateQuery: (query: string): Actions.ResetPageAndUpdateQuery => [

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -164,9 +164,7 @@ export function createActions(flux: FluxCapacitor) {
       // tslint:disable-next-line max-line-length
       resetRecall: (query: string = null, { field, index }: { field: string, index: number } = <any>{}): Actions.ResetRecall => {
         const resetActions: any = [
-          actions.resetPage(),
-          ...actions.resetRefinements(true),
-          ...actions.updateQuery(query)
+          ...actions.search()
         ];
         if (field) {
           resetActions.push(...actions.selectRefinement(field, index));

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -49,7 +49,7 @@ export function createActions(flux: FluxCapacitor) {
           searchActions.push(...actions.updateQuery(search.query));
         }
         if ('clear' in search && shouldResetRefinements(search, flux.store.getState())) {
-          searchActions.push(...actions.resetRefinements(search.query));
+          searchActions.push(...actions.resetRefinements(search.clear));
         }
         if ('navigationId' in search) {
           if ('index' in search) {

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -41,21 +41,33 @@ export function createActions(flux: FluxCapacitor) {
         action(Actions.FETCH_RECOMMENDATIONS_PRODUCTS, null, metadata),
 
       // request action creators
-      updateSearch: (search: Actions.Payload.Search): Actions.UpdateSearch =>
-        action(Actions.UPDATE_SEARCH,
-          'query' in search ? { ...search, query: search.query && search.query.trim() } : search,
-          {
-            ...metadata,
-            validator: {
-              payload: [{
-                func: ({ query }) => !('query' in search) || !!query || query === null,
-                msg: 'search term is empty'
-              }, {
-                func: ({ query }, state) => query !== Selectors.query(state) || query === null,
-                msg: 'search term is not different'
-              }]
-            }
-          }),
+      updateSearch: (search: Actions.Payload.Search) => {
+        const searchActions = [];
+
+        if ('query' in search) {
+          searchActions.push(actions.updateQuery(search.query));
+        }
+        // updateSearch: (search: Actions.Payload.Search): Actions.UpdateSearch => {
+        // action(Actions.UPDATE_SEARCH,
+        //   'query' in search ? { ...search, query: search.query && search.query.trim() } : search,
+        //   {
+        //     ...metadata,
+        //     validator: {
+        //       payload: [{
+        //         func: ({ query }) => !('query' in search) || !!query || query === null,
+        //         msg: 'search term is empty'
+        //       }, {
+        //         func: ({ query }, state) => query !== Selectors.query(state) || query === null,
+        //         msg: 'search term is not different'
+        //       }]
+        //     }
+        //   })
+        //
+        return searchActions;
+      },
+
+      updateQuery: (query: string): Actions.UpdateQuery =>
+        action(Actions.UPDATE_QUERY, query, metadata),
 
       addRefinement: (field: string, valueOrLow: any, high: any = null) =>
         actions.updateSearch(refinementPayload(field, valueOrLow, high)),

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -41,7 +41,7 @@ export function createActions(flux: FluxCapacitor) {
         action(Actions.FETCH_RECOMMENDATIONS_PRODUCTS, null, metadata),
 
       // request action creators
-      updateSearch: (search: Actions.Payload.Search) => {
+      updateSearch: (search: Actions.Payload.Search): any => {
         const searchActions: any[] = [actions.resetPage()];
 
         if ('query' in search) {
@@ -78,7 +78,14 @@ export function createActions(flux: FluxCapacitor) {
         }),
 
       addRefinement: (field: string, valueOrLow: any, high: any = null): Actions.AddRefinement =>
-        action(Actions.ADD_REFINEMENT, refinementPayload(field, valueOrLow, high), metadata),
+        action(Actions.ADD_REFINEMENT, refinementPayload(field, valueOrLow, high), {
+          ...metadata,
+          validator: {
+            payload: [{
+            //  func: (_, state) => field &&
+            }]
+          }
+        }),
 
       switchRefinement: (field: string, valueOrLow: any, high: any = null) =>
         actions.updateSearch({ ...refinementPayload(field, valueOrLow, high), clear: field }),

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -99,8 +99,8 @@ export function createActions(flux: FluxCapacitor) {
               func: (payload, state) => {
                 const navigation = Selectors.navigation(state, field);
                 // tslint:disable-next-line max-line-length
-                return !navigation || !navigation.selected
-                  .find((index) => SearchAdapter.refinementsMatch(payload, <any>navigation.refinements[index], navigation.range ? 'Range' : 'Value'));
+                return !navigation || navigation.selected
+                  .findIndex((index) => SearchAdapter.refinementsMatch(payload, <any>navigation.refinements[index], navigation.range ? 'Range' : 'Value')) === -1;
               },
               msg: 'refinement is already selected'
             }]
@@ -126,7 +126,7 @@ export function createActions(flux: FluxCapacitor) {
               func: (_, state) => Selectors.selectedRefinements(state).length !== 0,
               msg: 'no refinements to clear'
             }, {
-              func: (_, state) => typeof field === 'string' && Selectors.navigation(state, field).selected.length !== 0,
+              func: (_, state) => typeof field === 'boolean' || Selectors.navigation(state, field).selected.length !== 0,
               msg: `no refinements to clear for field "${field}"`
             }]
           }

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -4,8 +4,8 @@ import Actions from './actions';
 import SearchAdapter from './adapters/search';
 import Selectors from './selectors';
 import Store from './store';
-import * as validators from './validators';
 import { action, handleError, refinementPayload } from './utils';
+import * as validators from './validators';
 
 export function createActions(flux: FluxCapacitor) {
 
@@ -83,8 +83,24 @@ export function createActions(flux: FluxCapacitor) {
           ...metadata,
           validator: {
             navigationId: validators.isString,
-            payload: [
-            ]
+            payload: [{
+              func: ({ range }) => !range || (typeof valueOrLow === 'number' && typeof high === 'number'),
+              msg: 'low and high values must be numeric'
+            }, {
+              func: ({ range }) => !range || valueOrLow < high,
+              msg: 'low value must be lower than high'
+            }, {
+              func: ({ range }) => !!range || validators.isString.func(valueOrLow),
+              msg: `value ${validators.isString.msg}`
+            }, {
+              func: (payload, state) => {
+                const navigation = Selectors.navigation(state, field);
+                // tslint:disable-next-line max-line-length
+                return !navigation || !navigation.selected
+                  .find((index) => SearchAdapter.refinementsMatch(payload, <any>navigation.refinements[index], navigation.range ? 'Range' : 'Value'));
+              },
+              msg: 'refinement is already selected'
+            }]
           }
         }),
 

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -43,7 +43,7 @@ export function createActions(flux: FluxCapacitor) {
 
       // request action creators
       updateSearch: (search: Actions.Payload.Search): Actions.UpdateSearch => {
-        const searchActions: any = [actions.resetPage()];
+        const searchActions: Actions.UpdateSearch = [actions.resetPage()];
 
         if ('query' in search) {
           searchActions.push(...actions.updateQuery(search.query));
@@ -163,14 +163,12 @@ export function createActions(flux: FluxCapacitor) {
 
       // tslint:disable-next-line max-line-length
       resetRecall: (query: string = null, { field, index }: { field: string, index: number } = <any>{}): Actions.ResetRecall => {
-        const resetActions: any = [
-          ...actions.search()
-        ];
+        const resetActions: any[] = actions.search();
         if (field) {
           resetActions.push(...actions.selectRefinement(field, index));
         }
 
-        return resetActions;
+        return <Actions.ResetRecall>resetActions;
       },
 
       selectRefinement: (navigationId: string, index: number): Actions.ResetPageAndSelectRefinement => [

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -48,8 +48,8 @@ export function createActions(flux: FluxCapacitor) {
         if ('query' in search) {
           searchActions.push(...actions.updateQuery(search.query));
         }
-        if ('clear' in search) {
-          searchActions.push(...actions.checkAndResetRefinements(search));
+        if ('clear' in search && actions.shouldResetRefinements(search)) {
+          searchActions.push(...actions.resetRefinements(search.query));
         }
         if ('navigationId' in search) {
           if ('index' in search) {
@@ -64,14 +64,12 @@ export function createActions(flux: FluxCapacitor) {
         return searchActions;
       },
 
-      checkAndResetRefinements: ({ low, high, value, navigationId, range, clear }: Actions.Payload.Search):
-        Actions.CheckAndResetRefinements => {
+      shouldResetRefinements: ({ low, high, value, navigationId, range }: Actions.Payload.Search): boolean => {
         const currentRefinements = Selectors.selectedRefinements(flux.store.getState());
         const refinement = { low, high, value };
         // assumes only one refinement can be added at once
-        return (!navigationId || currentRefinements.length !== 1 ||
-          !SearchAdapter.refinementsMatch(<any>refinement, currentRefinements[0], range ? 'Range' : 'Value')) ?
-          actions.resetRefinements(clear) : [];
+        return !navigationId || currentRefinements.length !== 1 ||
+          !SearchAdapter.refinementsMatch(<any>refinement, currentRefinements[0], range ? 'Range' : 'Value');
       },
 
       updateQuery: (query: string): Actions.ResetPageAndUpdateQuery => [

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -4,6 +4,7 @@ import Actions from './actions';
 import SearchAdapter from './adapters/search';
 import Selectors from './selectors';
 import Store from './store';
+import * as validators from './validators';
 import { action, handleError, refinementPayload } from './utils';
 
 export function createActions(flux: FluxCapacitor) {
@@ -81,9 +82,9 @@ export function createActions(flux: FluxCapacitor) {
         action(Actions.ADD_REFINEMENT, refinementPayload(field, valueOrLow, high), {
           ...metadata,
           validator: {
-            payload: [{
-            //  func: (_, state) => field &&
-            }]
+            navigationId: validators.isString,
+            payload: [
+            ]
           }
         }),
 

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -4,7 +4,7 @@ import Actions from './actions';
 import SearchAdapter from './adapters/search';
 import Selectors from './selectors';
 import Store from './store';
-import { action, handleError, refinementPayload } from './utils';
+import { action, handleError, refinementPayload, shouldResetRefinements } from './utils';
 import * as validators from './validators';
 
 export function createActions(flux: FluxCapacitor) {
@@ -48,7 +48,7 @@ export function createActions(flux: FluxCapacitor) {
         if ('query' in search) {
           searchActions.push(...actions.updateQuery(search.query));
         }
-        if ('clear' in search && actions.shouldResetRefinements(search)) {
+        if ('clear' in search && shouldResetRefinements(search, flux.store.getState())) {
           searchActions.push(...actions.resetRefinements(search.query));
         }
         if ('navigationId' in search) {
@@ -62,14 +62,6 @@ export function createActions(flux: FluxCapacitor) {
         }
 
         return searchActions;
-      },
-
-      shouldResetRefinements: ({ low, high, value, navigationId, range }: Actions.Payload.Search): boolean => {
-        const currentRefinements = Selectors.selectedRefinements(flux.store.getState());
-        const refinement = { low, high, value };
-        // assumes only one refinement can be added at once
-        return !navigationId || currentRefinements.length !== 1 ||
-          !SearchAdapter.refinementsMatch(<any>refinement, currentRefinements[0], range ? 'Range' : 'Value');
       },
 
       updateQuery: (query: string): Actions.ResetPageAndUpdateQuery => [

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -42,7 +42,7 @@ export function createActions(flux: FluxCapacitor) {
 
       // request action creators
       updateSearch: (search: Actions.Payload.Search) => {
-        const searchActions = [];
+        const searchActions: any[] = [actions.resetPage()];
 
         if ('query' in search) {
           searchActions.push(actions.updateQuery(search.query));
@@ -85,6 +85,17 @@ export function createActions(flux: FluxCapacitor) {
             payload: {
               func: () => field === true || typeof field === 'string',
               msg: 'clear must be a string or true'
+            }
+          }
+        }),
+
+      resetPage: (): Actions.ResetPage =>
+        action(Actions.RESET_PAGE, undefined, {
+          ...metadata,
+          validator: {
+            payload: {
+              func: (_, state) => Selectors.page(state) !== 1,
+              msg: 'page must not be on first page'
             }
           }
         }),

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -47,6 +47,9 @@ export function createActions(flux: FluxCapacitor) {
         if ('query' in search) {
           searchActions.push(actions.updateQuery(search.query));
         }
+        if ('clear' in search) {
+          searchActions.push(actions.resetRefinements(search.clear));
+        }
         // updateSearch: (search: Actions.Payload.Search): Actions.UpdateSearch => {
         // action(Actions.UPDATE_SEARCH,
         //   'query' in search ? { ...search, query: search.query && search.query.trim() } : search,
@@ -75,8 +78,16 @@ export function createActions(flux: FluxCapacitor) {
       switchRefinement: (field: string, valueOrLow: any, high: any = null) =>
         actions.updateSearch({ ...refinementPayload(field, valueOrLow, high), clear: field }),
 
-      resetRefinements: () =>
-        actions.updateSearch({ clear: true }),
+      resetRefinements: (field?: boolean | string): Actions.ResetRefinements =>
+        action(Actions.RESET_REFINEMENTS, field, {
+          ...metadata,
+          validator: {
+            payload: {
+              func: () => field === true || typeof field === 'string',
+              msg: 'clear must be a string or true'
+            }
+          }
+        }),
 
       search: (query: string = Selectors.query(flux.store.getState())) =>
         actions.updateSearch({ query, clear: true }),

--- a/src/core/action-creator.ts
+++ b/src/core/action-creator.ts
@@ -65,12 +65,12 @@ export function createActions(flux: FluxCapacitor) {
       },
 
       checkAndResetRefinements: ({ low, high, value, navigationId, range, clear }: Actions.Payload.Search):
-      Actions.CheckAndResetRefinements => {
+        Actions.CheckAndResetRefinements => {
         const currentRefinements = Selectors.selectedRefinements(flux.store.getState());
         const refinement = { low, high, value };
         // assumes only one refinement can be added at once
         return (!navigationId || currentRefinements.length !== 1 ||
-                !SearchAdapter.refinementsMatch(<any>refinement, currentRefinements[0], range ? 'Range' : 'Value')) ?
+          !SearchAdapter.refinementsMatch(<any>refinement, currentRefinements[0], range ? 'Range' : 'Value')) ?
           actions.resetRefinements(clear) : [];
       },
 
@@ -136,6 +136,7 @@ export function createActions(flux: FluxCapacitor) {
               func: (_, state) => Selectors.selectedRefinements(state).length !== 0,
               msg: 'no refinements to clear'
             }, {
+              // tslint:disable-next-line max-line-length
               func: (_, state) => typeof field === 'boolean' || Selectors.navigation(state, field).selected.length !== 0,
               msg: `no refinements to clear for field "${field}"`
             }]

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -52,6 +52,8 @@ namespace Actions {
   export type ResetRefinements = Action<typeof RESET_REFINEMENTS, boolean | string>;
   export const RESET_PAGE = 'RESET_PAGE';
   export type ResetPage = Action<typeof RESET_PAGE, undefined>;
+  export const ADD_REFINEMENT = 'ADD_REFINEMENT';
+  export type AddRefinement = Action<typeof ADD_REFINEMENT, Actions.Payload.Navigation.AddRefinement>
 
   // fetch actions
   export const FETCH_MORE_REFINEMENTS = 'FETCH_MORE_REFINEMENTS';

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -53,7 +53,7 @@ namespace Actions {
   export const RESET_PAGE = 'RESET_PAGE';
   export type ResetPage = Action<typeof RESET_PAGE, undefined>;
   export const ADD_REFINEMENT = 'ADD_REFINEMENT';
-  export type AddRefinement = Action<typeof ADD_REFINEMENT, Actions.Payload.Navigation.AddRefinement>
+  export type AddRefinement = Action<typeof ADD_REFINEMENT, Actions.Payload.Navigation.AddRefinement>;
 
   // fetch actions
   export const FETCH_MORE_REFINEMENTS = 'FETCH_MORE_REFINEMENTS';

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -32,8 +32,6 @@ namespace Actions {
   export type UpdateAutocompleteQuery = Action<typeof UPDATE_AUTOCOMPLETE_QUERY, string>;
   export const UPDATE_DETAILS = 'UPDATE_DETAILS';
   export type UpdateDetails = Action<typeof UPDATE_DETAILS, Payload.Details>;
-  export const UPDATE_SEARCH = 'UPDATE_SEARCH';
-  export type UpdateSearch = Action<typeof UPDATE_SEARCH, Payload.Search>;
   export const SELECT_REFINEMENT = 'SELECT_REFINEMENT';
   export type SelectRefinement = Action<typeof SELECT_REFINEMENT, Payload.Navigation.Refinement>;
   export const DESELECT_REFINEMENT = 'DESELECT_REFINEMENT';
@@ -54,6 +52,21 @@ namespace Actions {
   export type ResetPage = Action<typeof RESET_PAGE, undefined>;
   export const ADD_REFINEMENT = 'ADD_REFINEMENT';
   export type AddRefinement = Action<typeof ADD_REFINEMENT, Actions.Payload.Navigation.AddRefinement>;
+
+  // batch actions
+  // tslint:disable-next-line max-line-length
+  export type SwitchRefinement = [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.AddRefinement];
+  export type Search = [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.AddRefinement];
+  // tslint:disable-next-line max-line-length
+  export type ResetRecall = [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.UpdateQuery] |
+    [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.UpdateQuery, Actions.ResetPage, Actions.SelectRefinement];
+    // tslint:disable-next-line max-line-length
+  export type UpdateSearch = Array<Actions.ResetPage | Actions.UpdateQuery | Actions.ResetRefinements | Actions.SelectRefinement | Actions.AddRefinement>;
+  export type ResetPageAndResetRefinements = [Actions.ResetPage, Actions.ResetRefinements];
+  export type ResetPageAndSelectRefinement = [Actions.ResetPage, Actions.SelectRefinement];
+  export type ResetPageAndDeselectRefinement = [Actions.ResetPage, Actions.DeselectRefinement];
+  export type ResetPageAndAddRefinement = [Actions.ResetPage, Actions.AddRefinement];
+  export type ResetPageAndUpdateQuery = [Actions.ResetPage, Actions.UpdateQuery];
 
   // fetch actions
   export const FETCH_MORE_REFINEMENTS = 'FETCH_MORE_REFINEMENTS';

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -32,6 +32,8 @@ namespace Actions {
   export type UpdateAutocompleteQuery = Action<typeof UPDATE_AUTOCOMPLETE_QUERY, string>;
   export const UPDATE_DETAILS = 'UPDATE_DETAILS';
   export type UpdateDetails = Action<typeof UPDATE_DETAILS, Payload.Details>;
+  export const UPDATE_SEARCH = 'UPDATE_SEARCH';
+  export type UpdateSearch = Action<typeof UPDATE_SEARCH, Payload.Search>;
   export const SELECT_REFINEMENT = 'SELECT_REFINEMENT';
   export type SelectRefinement = Action<typeof SELECT_REFINEMENT, Payload.Navigation.Refinement>;
   export const DESELECT_REFINEMENT = 'DESELECT_REFINEMENT';
@@ -61,7 +63,7 @@ namespace Actions {
   export type ResetRecall = [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.UpdateQuery] |
     [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.UpdateQuery, Actions.ResetPage, Actions.SelectRefinement];
     // tslint:disable-next-line max-line-length
-  export type UpdateSearch = Array<Actions.ResetPage | Actions.UpdateQuery | Actions.ResetRefinements | Actions.SelectRefinement | Actions.AddRefinement>;
+  // export type UpdateSearch = Array<Actions.ResetPage | Actions.UpdateQuery | Actions.ResetRefinements | Actions.SelectRefinement | Actions.AddRefinement>;
   export type ResetPageAndResetRefinements = [Actions.ResetPage, Actions.ResetRefinements];
   export type ResetPageAndSelectRefinement = [Actions.ResetPage, Actions.SelectRefinement];
   export type ResetPageAndDeselectRefinement = [Actions.ResetPage, Actions.DeselectRefinement];

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -49,7 +49,7 @@ namespace Actions {
   export const UPDATE_QUERY = 'UPDATE_QUERY';
   export type UpdateQuery = Action<typeof UPDATE_QUERY, string>;
   export const RESET_REFINEMENTS = 'RESET_REFINEMENTS';
-  export type ResetRefinements = Action<typeof RESET_REFINEMENTS, string>
+  export type ResetRefinements = Action<typeof RESET_REFINEMENTS, boolean | string>
 
   // fetch actions
   export const FETCH_MORE_REFINEMENTS = 'FETCH_MORE_REFINEMENTS';

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -68,6 +68,7 @@ namespace Actions {
   export type ResetPageAndSelectRefinement = [Actions.ResetPage, Actions.SelectRefinement];
   export type ResetPageAndDeselectRefinement = [Actions.ResetPage, Actions.DeselectRefinement];
   export type ResetPageAndAddRefinement = [Actions.ResetPage, Actions.AddRefinement];
+  export type CheckAndResetRefinements = ResetPageAndResetRefinements | Action<any>[];
   export type ResetPageAndUpdateQuery = [Actions.ResetPage, Actions.UpdateQuery];
 
   // fetch actions

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -32,8 +32,6 @@ namespace Actions {
   export type UpdateAutocompleteQuery = Action<typeof UPDATE_AUTOCOMPLETE_QUERY, string>;
   export const UPDATE_DETAILS = 'UPDATE_DETAILS';
   export type UpdateDetails = Action<typeof UPDATE_DETAILS, Payload.Details>;
-  export const UPDATE_SEARCH = 'UPDATE_SEARCH';
-  export type UpdateSearch = Action<typeof UPDATE_SEARCH, Payload.Search>;
   export const SELECT_REFINEMENT = 'SELECT_REFINEMENT';
   export type SelectRefinement = Action<typeof SELECT_REFINEMENT, Payload.Navigation.Refinement>;
   export const DESELECT_REFINEMENT = 'DESELECT_REFINEMENT';
@@ -63,7 +61,7 @@ namespace Actions {
   export type ResetRecall = [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.UpdateQuery] |
     [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.UpdateQuery, Actions.ResetPage, Actions.SelectRefinement];
     // tslint:disable-next-line max-line-length
-  // export type UpdateSearch = Array<Actions.ResetPage | Actions.UpdateQuery | Actions.ResetRefinements | Actions.SelectRefinement | Actions.AddRefinement>;
+  export type UpdateSearch = Array<Actions.ResetPage | Actions.UpdateQuery | Actions.ResetRefinements | Actions.SelectRefinement | Actions.AddRefinement>;
   export type ResetPageAndResetRefinements = [Actions.ResetPage, Actions.ResetRefinements];
   export type ResetPageAndSelectRefinement = [Actions.ResetPage, Actions.SelectRefinement];
   export type ResetPageAndDeselectRefinement = [Actions.ResetPage, Actions.DeselectRefinement];

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -27,6 +27,7 @@ namespace Actions {
     (dispatch: Dispatch<T>, getState?: () => Store.State);
   }
 
+  // update actions
   export const UPDATE_AUTOCOMPLETE_QUERY = 'UPDATE_AUTOCOMPLETE_QUERY';
   export type UpdateAutocompleteQuery = Action<typeof UPDATE_AUTOCOMPLETE_QUERY, string>;
   export const UPDATE_DETAILS = 'UPDATE_DETAILS';
@@ -45,6 +46,10 @@ namespace Actions {
   export type UpdatePageSize = Action<typeof UPDATE_PAGE_SIZE, number>;
   export const UPDATE_CURRENT_PAGE = 'UPDATE_CURRENT_PAGE';
   export type UpdateCurrentPage = Action<typeof UPDATE_CURRENT_PAGE, number>;
+  export const UPDATE_QUERY = 'UPDATE_QUERY';
+  export type UpdateQuery = Action<typeof UPDATE_QUERY, string>;
+  export const RESET_REFINEMENTS = 'RESET_REFINEMENTS';
+  export type ResetRefinements = Action<typeof RESET_REFINEMENTS, string>
 
   // fetch actions
   export const FETCH_MORE_REFINEMENTS = 'FETCH_MORE_REFINEMENTS';

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -49,7 +49,9 @@ namespace Actions {
   export const UPDATE_QUERY = 'UPDATE_QUERY';
   export type UpdateQuery = Action<typeof UPDATE_QUERY, string>;
   export const RESET_REFINEMENTS = 'RESET_REFINEMENTS';
-  export type ResetRefinements = Action<typeof RESET_REFINEMENTS, boolean | string>
+  export type ResetRefinements = Action<typeof RESET_REFINEMENTS, boolean | string>;
+  export const RESET_PAGE = 'RESET_PAGE';
+  export type ResetPage = Action<typeof RESET_PAGE, undefined>;
 
   // fetch actions
   export const FETCH_MORE_REFINEMENTS = 'FETCH_MORE_REFINEMENTS';

--- a/src/core/adapters/search.ts
+++ b/src/core/adapters/search.ts
@@ -2,6 +2,7 @@ import {
   Navigation,
   PageInfo,
   RangeRefinement,
+  Refinement,
   Results,
   SortType,
   Template,
@@ -45,8 +46,7 @@ namespace Adapter {
     sort: navigation.sort && Adapter.extractNavigationSort(navigation.sort),
   });
 
-  // tslint:disable-next-line max-line-length
-  export const refinementsMatch = (lhs: Store.RangeRefinement | Store.ValueRefinement, rhs: RangeRefinement | ValueRefinement, type: string = rhs.type) => {
+  export const refinementsMatch = (lhs: Store.Refinement, rhs: Refinement, type: string = rhs.type) => {
     if (type === 'Value') {
       return (<any>lhs).value === (<any>rhs).value;
     } else {

--- a/src/core/reducers/data/navigations.ts
+++ b/src/core/reducers/data/navigations.ts
@@ -95,7 +95,7 @@ export const deselectRefinement = (state: State, { navigationId, index: refineme
   }
 };
 
-const generateNavigationId = (state: State, navigationId: string, refinement: any, index: number) => ({
+const generateNavigation = (state: State, navigationId: string, refinement: any, index: number) => ({
   ...state.byId[navigationId],
   ...(index === -1
       ? {
@@ -125,7 +125,7 @@ export const addRefinement = (state: State, { navigationId, value, low, high, ra
       ...state,
       byId: {
         ...state.byId,
-        [navigationId]: generateNavigationId(state, navigationId, refinement, index)
+        [navigationId]: generateNavigation(state, navigationId, refinement, index)
       }
     };
   } else {

--- a/src/core/reducers/data/navigations.ts
+++ b/src/core/reducers/data/navigations.ts
@@ -17,7 +17,7 @@ export const DEFAULTS: State = {
 
 export default function updateNavigations(state: State = DEFAULTS, action: Action) {
   switch (action.type) {
-    case Actions.RESET_REFINEMENTS: return resetRefinements(state,action.payload);
+    case Actions.RESET_REFINEMENTS: return resetRefinements(state, action.payload);
     case Actions.RECEIVE_NAVIGATIONS: return receiveNavigations(state, action.payload);
     case Actions.ADD_REFINEMENT: return addRefinement(state, action.payload);
     case Actions.SELECT_REFINEMENT: return selectRefinement(state, action.payload);
@@ -95,37 +95,22 @@ export const deselectRefinement = (state: State, { navigationId, index: refineme
   }
 };
 
-// tslint:disable-next-line max-line-length
-export const addRefinementByIndex = (state: State, { navigationId, index: refinementIndex }: Actions.Payload.Search) => {
-
-  return {
-    ...state,
-    byId: {
-      ...state.byId,
-      [navigationId]: {
-        ...state.byId[navigationId],
-        selected: [refinementIndex],
-      },
-    },
-  };
-};
-
 const generateNavigationId = (state: State, navigationId: string, refinement: any, index: number) => ({
   ...state.byId[navigationId],
   ...(index === -1
-      ? {
-        refinements: [
-          ...state.byId[navigationId].refinements,
-          refinement
-        ],
-        selected: [
-          ...state.byId[navigationId].selected,
-          state.byId[navigationId].refinements.length
-        ]
-      }
-      : {
-        selected: [...state.byId[navigationId].selected, index]
-      })
+    ? {
+      refinements: [
+        ...state.byId[navigationId].refinements,
+        refinement
+      ],
+      selected: [
+        ...state.byId[navigationId].selected,
+        state.byId[navigationId].refinements.length
+      ]
+    }
+    : {
+      selected: [...state.byId[navigationId].selected, index]
+    })
 });
 
 // tslint:disable-next-line max-line-length

--- a/src/core/reducers/data/navigations.ts
+++ b/src/core/reducers/data/navigations.ts
@@ -98,19 +98,19 @@ export const deselectRefinement = (state: State, { navigationId, index: refineme
 const generateNavigationId = (state: State, navigationId: string, refinement: any, index: number) => ({
   ...state.byId[navigationId],
   ...(index === -1
-    ? {
-      refinements: [
-        ...state.byId[navigationId].refinements,
-        refinement
-      ],
-      selected: [
-        ...state.byId[navigationId].selected,
-        state.byId[navigationId].refinements.length
-      ]
-    }
-    : {
-      selected: [...state.byId[navigationId].selected, index]
-    })
+      ? {
+        refinements: [
+          ...state.byId[navigationId].refinements,
+          refinement
+        ],
+        selected: [
+          ...state.byId[navigationId].selected,
+          state.byId[navigationId].refinements.length
+        ]
+      }
+      : {
+        selected: [...state.byId[navigationId].selected, index]
+      })
 });
 
 // tslint:disable-next-line max-line-length

--- a/src/core/reducers/data/navigations.ts
+++ b/src/core/reducers/data/navigations.ts
@@ -2,7 +2,7 @@ import Actions from '../../actions';
 import Adapter from '../../adapters/search';
 import Store from '../../store';
 
-export type Action = Actions.UpdateSearch
+export type Action = Actions.ResetRefinements
   | Actions.ReceiveNavigations
   | Actions.SelectRefinement
   | Actions.DeselectRefinement
@@ -16,7 +16,8 @@ export const DEFAULTS: State = {
 
 export default function updateNavigations(state: State = DEFAULTS, action: Action) {
   switch (action.type) {
-    case Actions.UPDATE_SEARCH: return updateSearch(state, action.payload);
+    case Actions.RESET_REFINEMENTS: return resetRefinements(state,action.payload);
+    // case Actions.UPDATE_SEARCH: return updateSearch(state, action.payload);
     case Actions.RECEIVE_NAVIGATIONS: return receiveNavigations(state, action.payload);
     case Actions.SELECT_REFINEMENT: return selectRefinement(state, action.payload);
     case Actions.DESELECT_REFINEMENT: return deselectRefinement(state, action.payload);
@@ -26,26 +27,26 @@ export default function updateNavigations(state: State = DEFAULTS, action: Actio
 }
 
 export const updateSearch = (state: State, payload: Actions.Payload.Search) => {
-  if (payload.clear in state.byId) {
-    const navigationId = <string>payload.clear;
+  // if (payload.clear in state.byId) {
+  //   const navigationId = <string>payload.clear;
 
-    state = {
-      ...state,
-      byId: {
-        ...state.byId,
-        [navigationId]: {
-          ...state.byId[navigationId],
-          selected: []
-        }
-      }
-    };
-  } else if (payload.clear) {
-    state = {
-      ...state,
-      byId: state.allIds.reduce((navs, nav) =>
-        Object.assign(navs, { [nav]: { ...state.byId[nav], selected: [] } }), {})
-    };
-  }
+  //   state = {
+  //     ...state,
+  //     byId: {
+  //       ...state.byId,
+  //       [navigationId]: {
+  //         ...state.byId[navigationId],
+  //         selected: []
+  //       }
+  //     }
+  //   };
+  // } else if (payload.clear) {
+  //   state = {
+  //     ...state,
+  //     byId: state.allIds.reduce((navs, nav) =>
+  //       Object.assign(navs, { [nav]: { ...state.byId[nav], selected: [] } }), {})
+  //   };
+  // }
 
   if ('navigationId' in payload) {
     if ('index' in payload) {
@@ -55,6 +56,27 @@ export const updateSearch = (state: State, payload: Actions.Payload.Search) => {
     }
   } else {
     return state;
+  }
+};
+
+export const resetRefinements = (state: State, navigationId: boolean | string) => {
+  if (typeof navigationId === 'boolean') {
+    return {
+      ...state,
+      byId: state.allIds.reduce((navs, nav) =>
+        Object.assign(navs, { [nav]: { ...state.byId[nav], selected: [] } }), {})
+    };
+  } else {
+    return {
+      ...state,
+      byId: {
+        ...state.byId,
+        [navigationId]: {
+          ...state.byId[navigationId],
+          selected: []
+        }
+      }
+    };
   }
 };
 

--- a/src/core/reducers/data/page.ts
+++ b/src/core/reducers/data/page.ts
@@ -1,11 +1,9 @@
 import Actions from '../../actions';
 import Store from '../../store';
 
-export type Action = Actions.UpdateSearch
+export type Action = Actions.ResetPage
   | Actions.SelectSort
   | Actions.SelectCollection
-  | Actions.SelectRefinement
-  | Actions.DeselectRefinement
   | Actions.UpdateCurrentPage
   | Actions.UpdatePageSize
   | Actions.ReceivePage;
@@ -24,11 +22,9 @@ export const DEFAULTS: State = {
 
 export default function updatePage(state: State = DEFAULTS, action: Action): State {
   switch (action.type) {
-    case Actions.UPDATE_SEARCH:
+    case Actions.RESET_PAGE:
     case Actions.SELECT_SORT:
     case Actions.SELECT_COLLECTION:
-    case Actions.SELECT_REFINEMENT:
-    case Actions.DESELECT_REFINEMENT:
       return resetPage(state);
     case Actions.UPDATE_CURRENT_PAGE: return updateCurrent(state, action.payload);
     case Actions.UPDATE_PAGE_SIZE: return updateSize(state, action.payload);

--- a/src/core/reducers/data/query.ts
+++ b/src/core/reducers/data/query.ts
@@ -1,7 +1,7 @@
 import Actions from '../../actions';
 import Store from '../../store';
 
-export type Action = Actions.UpdateSearch | Actions.ReceiveQuery;
+export type Action = Actions.UpdateQuery | Actions.ReceiveQuery;
 export type State = Store.Query;
 
 export const DEFAULTS: State = {
@@ -12,14 +12,14 @@ export const DEFAULTS: State = {
 
 export default function updateQuery(state: State = DEFAULTS, action: Action): State {
   switch (action.type) {
-    case Actions.UPDATE_SEARCH: return updateOriginal(state, action.payload);
+    case Actions.UPDATE_QUERY: return updateOriginal(state, action.payload);
     case Actions.RECEIVE_QUERY: return receiveQuery(state, action.payload);
     default: return state;
   }
 }
 
-export const updateOriginal = (state: State, payload: Actions.Payload.Search) =>
-  'query' in payload ? ({ ...state, original: payload.query }) : state;
+export const updateOriginal = (state: State, query: string) =>
+  ({ ...state, original: query });
 
 export const receiveQuery = (state: State, { corrected, didYouMean, related, rewrites }: Actions.Payload.Query) =>
   ({ ...state, corrected, didYouMean, related, rewrites });

--- a/src/core/reducers/ui.ts
+++ b/src/core/reducers/ui.ts
@@ -3,15 +3,18 @@ import Store from '../store';
 
 export type Action = Actions.CreateComponentState
   | Actions.RemoveComponentState
-  | Actions.UpdateSearch;
+  | Actions.Action<any>;
 export type State = Store.UI;
 
-export default function updateUi(state: State = {}, action: Action): State {
-  switch (action.type) {
-    case Actions.CREATE_COMPONENT_STATE: return createComponentState(state, action.payload);
-    case Actions.REMOVE_COMPONENT_STATE: return removeComponentState(state, action.payload);
-    case Actions.UPDATE_SEARCH: return clearComponentState(state, action.payload);
-    default: return state;
+export default function updateUi(state: State = {}, { type, payload, meta = <Actions.Metadata>{} }: Action): State {
+  switch (type) {
+    case Actions.CREATE_COMPONENT_STATE: return createComponentState(state, payload);
+    case Actions.REMOVE_COMPONENT_STATE: return removeComponentState(state, payload);
+    default:
+      if ('recallId' in meta) {
+        return clearComponentState(state);
+      }
+      return state;
   }
 }
 
@@ -34,5 +37,4 @@ export const removeComponentState = (state: State, { tagName, id }: Actions.Payl
     }
   });
 
-export const clearComponentState = (state: State, payload: Actions.Payload.Search) =>
-  'query' in payload ? ({}) : state;
+export const clearComponentState = (state: State): State => ({});

--- a/src/core/store/middleware.ts
+++ b/src/core/store/middleware.ts
@@ -6,7 +6,9 @@ import Actions from '../actions';
 import * as Events from '../events';
 
 export const RECALL_CHANGE_ACTIONS = [
-  Actions.UPDATE_SEARCH,
+  Actions.RESET_REFINEMENTS,
+  Actions.UPDATE_QUERY,
+  Actions.ADD_REFINEMENT,
   Actions.SELECT_REFINEMENT,
   Actions.DESELECT_REFINEMENT,
 ];

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,5 +1,7 @@
 import * as fetchPonyfill from 'fetch-ponyfill';
 import Actions from './actions';
+import SearchAdapter from './adapters/search';
+import Selectors from './selectors';
 
 export const { fetch } = fetchPonyfill();
 
@@ -40,5 +42,14 @@ export const refinementPayload = (field: string, valueOrLow: any, high: any = nu
 
 // a passthrough to allow error to propagate to middleware
 // tslint:disable-next-line max-line-length
-export const handleError = (action: Actions.Action<any>,  createAction: () => any) =>
-  action.error ? action :  createAction();
+export const handleError = (errorAction: Actions.Action<any>,  createAction: () => any) =>
+  errorAction.error ? errorAction :  createAction();
+
+export const shouldResetRefinements =  ({ low, high, value, navigationId, range }: Actions.Payload.Search,
+                                        state: any): boolean => {
+  const currentRefinements = Selectors.selectedRefinements(state);
+  const refinement = { low, high, value };
+  // assumes only one refinement can be added at once
+  return !navigationId || currentRefinements.length !== 1 ||
+    !SearchAdapter.refinementsMatch(<any>refinement, currentRefinements[0], range ? 'Range' : 'Value');
+};

--- a/src/core/validators.ts
+++ b/src/core/validators.ts
@@ -1,0 +1,4 @@
+export const isString = (name: string) => ({
+    func: (value: any) => typeof value === 'string' && value.trim().length !== 0,
+    msg: `"${name}" must be a non-empty string`
+});

--- a/src/core/validators.ts
+++ b/src/core/validators.ts
@@ -1,4 +1,11 @@
-export const isString = (name: string) => ({
+import Store from './store';
+
+export interface Validator<T> {
+  func: (payload?: T, state?: Store.State) => boolean;
+  msg: string;
+}
+
+export const isString: Validator<string> = ({
     func: (value: any) => typeof value === 'string' && value.trim().length !== 0,
-    msg: `"${name}" must be a non-empty string`
+    msg: 'must be a non-empty string'
 });

--- a/src/flux-capacitor.ts
+++ b/src/flux-capacitor.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'eventemitter3';
 import { BrowserBridge, Results } from 'groupby-api';
-import { Store as ReduxStore } from 'redux';
+import { Action as ReduxAction, Store as ReduxStore } from 'redux';
 import { Sayt } from 'sayt';
 import createActions from './core/action-creator';
 import Actions from './core/actions';
@@ -10,6 +10,13 @@ import * as Events from './core/events';
 import Observer from './core/observer';
 import Selectors from './core/selectors';
 import Store from './core/store';
+
+declare module 'redux' {
+  export interface Dispatch<S> {
+    <A extends ReduxAction>(action: A): A;
+    <A extends ReduxAction>(action: A[]): A[];
+  }
+}
 
 class FluxCapacitor extends EventEmitter {
 

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -142,14 +142,15 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
       });
 
       it('should return a bulk action with RESET_REFINEMENTS', () => {
+        flux.store = { getState: () => null };
         const clear = 'q';
-        const shouldResetRefinements = stub(actions, 'shouldResetRefinements').returns(true);
+        const shouldResetRefinements = stub(utils, 'shouldResetRefinements').returns(true);
         const resetRefinements = stub(actions, 'resetRefinements').returns([ACTION]);
 
         const batchAction = actions.updateSearch({ clear });
 
         expect(batchAction).to.eql([resetPageAction, ACTION]);
-        expect(shouldResetRefinements).to.be.calledWithExactly({ clear });
+        expect(shouldResetRefinements).to.be.calledWithExactly({ clear }, null);
       });
 
       it('should return a bulk action with SELECT_REFINEMENT', () => {

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -194,49 +194,6 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
       });
     });
 
-    describe('shouldResetRefinements()', () => {
-      it('should call RESET_REFINEMENTS if refinementsMatch is false', () => {
-        stub(Selectors, 'selectedRefinements').returns(['hello']);
-        stub(SearchAdapter, 'refinementsMatch').returns(false);
-
-        flux.store = { getState: () => [] };
-        expect(actions.shouldResetRefinements({ navigationId: 'truthy' })).to.be.true;
-      });
-
-      it('should call RESET_REFINEMENTS if currentRefinements length is not 1', () => {
-        stub(Selectors, 'selectedRefinements').returns(['hello', 'hello']);
-        stub(SearchAdapter, 'refinementsMatch').returns(true);
-
-        flux.store = { getState: () => [] };
-        expect(actions.shouldResetRefinements({ navigationId: 'truthy' })).to.be.true;
-      });
-
-      it('should call RESET_REFINEMENTS if navigationId is falsy', () => {
-        stub(Selectors, 'selectedRefinements').returns(['hello']);
-        stub(SearchAdapter, 'refinementsMatch').returns(true);
-
-        flux.store = { getState: () => [] };
-        // undefined is falsy
-        expect(actions.shouldResetRefinements({ navigationId: undefined })).to.be.true;
-      });
-
-      it('should return [] all above conditions are false', () => {
-        stub(Selectors, 'selectedRefinements').returns(['hello']);
-        stub(SearchAdapter, 'refinementsMatch').returns(true);
-
-        flux.store = { getState: () => [] };
-        expect(actions.shouldResetRefinements({ navigationId: 'truthy' })).to.be.false;
-      });
-
-      it('should return [] all above conditions are false (range is truthy case)', () => {
-        stub(Selectors, 'selectedRefinements').returns(['hello']);
-        stub(SearchAdapter, 'refinementsMatch').returns(true);
-
-        flux.store = { getState: () => [] };
-        expect(actions.shouldResetRefinements({ navigationId: 'truthy', range: true })).to.be.false;
-      });
-    });
-
     describe('updateQuery()', () => {
       it('should return a batch action with RESET_PAGE', () => {
         const query = 'rambo';

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -285,31 +285,25 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
 
     describe('addRefinement()', () => {
       const navigationId = 'book';
+      const refinement = { c: 'd' };
 
-      it('should add a value refinement', () => {
-        const action = { a: 'b' };
-        const refinement = { c: 'd' };
+      it('should return an action with value refinement', () => {
         const value = 'a';
-        const updateSearch = stub(actions, 'updateSearch').returns(action);
         const refinementPayload = stub(utils, 'refinementPayload').returns(refinement);
 
-        const result = actions.addRefinement(navigationId, value);
-
-        expect(result).to.be.eq(action);
-        expect(updateSearch).to.be.calledWithExactly(refinement);
+        expectAction(() => actions.addRefinement(navigationId, value), Actions.ADD_REFINEMENT, refinement);
         expect(refinementPayload).to.be.calledWithExactly(navigationId, value, null);
       });
 
-      it('should add a range refinement', () => {
-        const low = 20;
-        const high = 57;
-        const refinementPayload = stub(utils, 'refinementPayload');
-        stub(actions, 'updateSearch');
+      it('should return an action with range refinement', () => {
+        const low = 2;
+        const high = 4;
+        const refinementPayload = stub(utils, 'refinementPayload').returns(refinement);
 
-        actions.addRefinement(navigationId, low, high);
-
+        expectAction(() => actions.addRefinement(navigationId, low, high), Actions.ADD_REFINEMENT, refinement);
         expect(refinementPayload).to.be.calledWithExactly(navigationId, low, high);
       });
+
     });
 
     describe('switchRefinement()', () => {

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -121,60 +121,66 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
   describe('request action creators', () => {
     describe('updateSearch()', () => {
       it('should return an action with validation if search contains query', () => {
-        const search: any = { a: 'b', query: 'q' };
+        const query = 'q';
+        const updateQuery = actions.updateQuery = spy(() => ACTION);
 
-        expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
-          (meta) => {
-            expect(meta.validator.payload[0].func({})).to.be.false;
-            expect(meta.validator.payload[0].func({ query: '' })).to.be.false;
-            expect(meta.validator.payload[0].func({ query: undefined })).to.be.false;
-            return expect(meta.validator.payload[0].func({ query: null })).to.be.true;
-          });
+        const actualActions = actions.updateSearch({ query });
+
+        expect(actualActions).to.eql([ACTION]);
+        expect(updateQuery).to.be.calledWithExactly(query);
       });
 
-      it('should return an action with validation if search does not contain query', () => {
-        const search: any = { a: 'b' };
+      // it('should return an action with validation if search does not contain query', () => {
+      //   const search: any = { a: 'b' };
+      //
+      //   expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
+      //     (meta) => {
+      //       expect(meta.validator.payload[0].func({})).to.be.true;
+      //       return expect(meta.validator.payload[0].func({ query: 'q' })).to.be.true;
+      //     });
+      // });
+      //
+      // it('should return an action with validation if search term is not different', () => {
+      //   const query = 'book';
+      //   const search: any = { a: 'b' };
+      //   const state = { a: 'b' };
+      //   stub(Selectors, 'query').withArgs(state).returns(query);
+      //
+      //   expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
+      //     (meta) => expect(meta.validator.payload[1].func({ query }, state)).to.be.false);
+      // });
+      //
+      // it('should return an action with validation if search term is different', () => {
+      //   const search: any = { a: 'b' };
+      //   const state = { a: 'b' };
+      //   stub(Selectors, 'query').withArgs(state).returns('book');
+      //
+      //   expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
+      //     (meta) => expect(meta.validator.payload[1].func({ query: 'boot' }, state)).to.be.true);
+      // });
+      //
+      // it('should return an action with validation if search term is null', () => {
+      //   const query = null;
+      //   const search: any = { a: 'b' };
+      //   const state = { a: 'b' };
+      //   stub(Selectors, 'query').withArgs(state).returns(query);
+      //
+      //   expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
+      //     (meta) => expect(meta.validator.payload[1].func({ query }, state)).to.be.true);
+      // });
+      //
+      // it('should trim query', () => {
+      //   const search: any = { query: '  untrimmed \n \r  ' };
+      //
+      //   expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, { query: 'untrimmed' });
+      // });
+    });
 
-        expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
-          (meta) => {
-            expect(meta.validator.payload[0].func({})).to.be.true;
-            return expect(meta.validator.payload[0].func({ query: 'q' })).to.be.true;
-          });
-      });
+    describe('updateQuery()', () => {
+      it('should return an action', () => {
+        const query = 'rambo';
 
-      it('should return an action with validation if search term is not different', () => {
-        const query = 'book';
-        const search: any = { a: 'b' };
-        const state = { a: 'b' };
-        stub(Selectors, 'query').withArgs(state).returns(query);
-
-        expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
-          (meta) => expect(meta.validator.payload[1].func({ query }, state)).to.be.false);
-      });
-
-      it('should return an action with validation if search term is different', () => {
-        const search: any = { a: 'b' };
-        const state = { a: 'b' };
-        stub(Selectors, 'query').withArgs(state).returns('book');
-
-        expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
-          (meta) => expect(meta.validator.payload[1].func({ query: 'boot' }, state)).to.be.true);
-      });
-
-      it('should return an action with validation if search term is null', () => {
-        const query = null;
-        const search: any = { a: 'b' };
-        const state = { a: 'b' };
-        stub(Selectors, 'query').withArgs(state).returns(query);
-
-        expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
-          (meta) => expect(meta.validator.payload[1].func({ query }, state)).to.be.true);
-      });
-
-      it('should trim query', () => {
-        const search: any = { query: '  untrimmed \n \r  ' };
-
-        expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, { query: 'untrimmed' });
+        expectAction(() => actions.updateQuery(query), Actions.UPDATE_QUERY, query);
       });
     });
 

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -549,27 +549,14 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
       const resetRefinementsAction = { c: 'd' };
       const updateQueryAction = { e: 'f' };
 
-      it('should return bulk action with RESET_PAGE, RESET_REFINEMENTS and UPDATE_QUERY', () => {
-        const resetRefinements = actions.resetRefinements = spy(() => resetRefinementsAction);
-        const updateQuery = actions.updateQuery = spy(() => updateQueryAction);
-        actions.resetPage = (): any => resetPageAction;
+      it('should call search() if field not provided and return result of search()', () => {
+        const ret = ['1'];
+        const search = stub(actions, 'search').returns(ret);
 
         const batchAction = actions.resetRecall();
 
-        expect(batchAction).to.eql([resetPageAction, resetRefinementsAction, updateQueryAction]);
-        expect(resetRefinements).to.be.calledWithExactly(true);
-        expect(updateQuery).to.be.calledWithExactly(null);
-      });
-
-      it('should UPDATE_QUERY from query', () => {
-        const query = 'basketball';
-        const updateQuery = actions.updateQuery = spy();
-        actions.resetRefinements = () => null;
-        actions.resetPage = () => null;
-
-        actions.resetRecall(query);
-
-        expect(updateQuery).to.be.calledWithExactly(query);
+        expect(batchAction).to.eql(ret);
+        expect(search).to.be.calledOnce;
       });
 
       it('should return bulk action with SELECT_REFINEMENT if field and index provided', () => {
@@ -577,9 +564,11 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const index = 8;
         const selectRefinementAction = { g: 'h' };
         const selectRefinement = actions.selectRefinement = spy(() => [selectRefinementAction]);
-        actions.resetRefinements = (): any => [resetRefinementsAction];
-        actions.updateQuery = (): any => [updateQueryAction];
-        actions.resetPage = (): any => resetPageAction;
+        const search = stub(actions, 'search').returns([
+          resetPageAction,
+          resetRefinementsAction,
+          updateQueryAction,
+        ]);
 
         const batchAction = actions.resetRecall('', { field, index });
 

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -185,6 +185,12 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         expect(batchAction).to.eql([resetPageAction, ACTION]);
         expect(addRefinement).to.be.calledWithExactly(navigationId, low, high);
       });
+
+      it('should return a bulk action without ADD_REFINEMENT', () => {
+        const batchAction = actions.updateSearch({ navigationId: 'truthy' });
+
+        expect(batchAction).to.eql([resetPageAction]);
+      });
     });
 
     describe('checkAndResetRefinements()', () => {
@@ -226,6 +232,16 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
 
         flux.store = { getState: () => [] };
         let result = actions.checkAndResetRefinements({ navigationId: 'truthy' });
+        expect(result).to.be.eql([]);
+      });
+
+      it('should return [] all above conditions are false (range is truthy case)', () => {
+        const resetRefinements = stub(actions, 'resetRefinements');
+        stub(Selectors, 'selectedRefinements').returns(['hello']);
+        stub(SearchAdapter, 'refinementsMatch').returns(true);
+
+        flux.store = { getState: () => [] };
+        let result = actions.checkAndResetRefinements({ navigationId: 'truthy', range: true });
         expect(result).to.be.eql([]);
       });
     });
@@ -1035,6 +1051,14 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
 
         // tslint:disable-next-line max-line-length
         expectAction(() => actions.createComponentState(tagName, id, state), Actions.CREATE_COMPONENT_STATE, { tagName, id, state });
+      });
+
+      it('should return an action if no state is passed as an argument', () => {
+        const tagName = 'my-tag';
+        const id = '123';
+
+        // tslint:disable-next-line max-line-length
+        expectAction(() => actions.createComponentState(tagName, id), Actions.CREATE_COMPONENT_STATE, { tagName, id, state: {} });
       });
     });
 

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -150,6 +150,17 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         expect(resetRefinements).to.be.calledWithExactly(clear);
       });
 
+      it('should return a bulk action with SELECT_REFINEMENT', () => {
+        const navigationId = 'color';
+        const index = 4;
+        const selectRefinement = actions.selectRefinement = spy(() => ACTION);
+
+        const batchAction = actions.updateSearch({ navigationId, index });
+
+        expect(batchAction).to.eql([resetPageAction, ACTION]);
+        expect(selectRefinement).to.be.calledWithExactly(navigationId, index);
+      });
+
       // it('should return an action with validation if search does not contain query', () => {
       //   const search: any = { a: 'b' };
       //
@@ -229,14 +240,30 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const field = 'brand';
 
         expectAction(() => actions.resetRefinements(field), Actions.RESET_REFINEMENTS, field,
-          (meta) => expect(meta.validator.payload.func()).to.be.true);
+          (meta) => expect(meta.validator.payload[0].func()).to.be.true);
       });
 
-      it('should not return an action', () => {
+      it('should not return an action when field is invalid', () => {
         const field = false;
 
         expectAction(() => actions.resetRefinements(field), Actions.RESET_REFINEMENTS, field,
-          (meta) => expect(meta.validator.payload.func()).to.be.false);
+          (meta) => expect(meta.validator.payload[0].func()).to.be.false);
+      });
+
+      it('should not return an action when no refinements selected', () => {
+        stub(Selectors, 'selectedRefinements').returns([]);
+
+        expectAction(() => actions.resetRefinements(), Actions.RESET_REFINEMENTS, undefined,
+          (meta) => expect(meta.validator.payload[1].func()).to.be.false);
+      });
+
+      it('should not return an action when no refinements selected for field', () => {
+        const field = 'brand';
+        stub(Selectors, 'selectedRefinements').returns([{}]);
+        stub(Selectors, 'navigation').returns({ selected: [] });
+
+        expectAction(() => actions.resetRefinements(field), Actions.RESET_REFINEMENTS, field,
+          (meta) => expect(meta.validator.payload[2].func()).to.be.false);
       });
     });
 

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -133,7 +133,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
 
       it('should return a bulk action with UPDATE_QUERY', () => {
         const query = 'q';
-        const updateQuery = actions.updateQuery = spy(() => ACTION);
+        const updateQuery = actions.updateQuery = spy(() => [ACTION]);
 
         const batchAction = actions.updateSearch({ query });
 
@@ -143,7 +143,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
 
       it('should return a bulk action with RESET_REFINEMENTS', () => {
         const clear = 'q';
-        const resetRefinements = actions.resetRefinements = spy(() => ACTION);
+        const resetRefinements = actions.resetRefinements = spy(() => [ACTION]);
 
         const batchAction = actions.updateSearch({ clear });
 
@@ -154,7 +154,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
       it('should return a bulk action with SELECT_REFINEMENT', () => {
         const navigationId = 'color';
         const index = 4;
-        const selectRefinement = actions.selectRefinement = spy(() => ACTION);
+        const selectRefinement = actions.selectRefinement = spy(() => [ACTION]);
 
         const batchAction = actions.updateSearch({ navigationId, index });
 
@@ -165,7 +165,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
       it('should return a bulk action with value ADD_REFINEMENT', () => {
         const navigationId = 'color';
         const value = 'blue';
-        const addRefinement = actions.addRefinement = spy(() => ACTION);
+        const addRefinement = actions.addRefinement = spy(() => [ACTION]);
 
         const batchAction = actions.updateSearch({ navigationId, value });
 
@@ -178,66 +178,32 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const range = true;
         const low = 1;
         const high = 2;
-        const addRefinement = actions.addRefinement = spy(() => ACTION);
+        const addRefinement = actions.addRefinement = spy(() => [ACTION]);
 
         const batchAction = actions.updateSearch({ navigationId, range, low, high });
 
         expect(batchAction).to.eql([resetPageAction, ACTION]);
         expect(addRefinement).to.be.calledWithExactly(navigationId, low, high);
       });
-
-      // it('should return an action with validation if search does not contain query', () => {
-      //   const search: any = { a: 'b' };
-      //
-      //   expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
-      //     (meta) => {
-      //       expect(meta.validator.payload[0].func({})).to.be.true;
-      //       return expect(meta.validator.payload[0].func({ query: 'q' })).to.be.true;
-      //     });
-      // });
-      //
-      // it('should return an action with validation if search term is not different', () => {
-      //   const query = 'book';
-      //   const search: any = { a: 'b' };
-      //   const state = { a: 'b' };
-      //   stub(Selectors, 'query').withArgs(state).returns(query);
-      //
-      //   expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
-      //     (meta) => expect(meta.validator.payload[1].func({ query }, state)).to.be.false);
-      // });
-      //
-      // it('should return an action with validation if search term is different', () => {
-      //   const search: any = { a: 'b' };
-      //   const state = { a: 'b' };
-      //   stub(Selectors, 'query').withArgs(state).returns('book');
-      //
-      //   expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
-      //     (meta) => expect(meta.validator.payload[1].func({ query: 'boot' }, state)).to.be.true);
-      // });
-      //
-      // it('should return an action with validation if search term is null', () => {
-      //   const query = null;
-      //   const search: any = { a: 'b' };
-      //   const state = { a: 'b' };
-      //   stub(Selectors, 'query').withArgs(state).returns(query);
-      //
-      //   expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, search,
-      //     (meta) => expect(meta.validator.payload[1].func({ query }, state)).to.be.true);
-      // });
-      //
-      // it('should trim query', () => {
-      //   const search: any = { query: '  untrimmed \n \r  ' };
-      //
-      //   expectAction(() => actions.updateSearch(search), Actions.UPDATE_SEARCH, { query: 'untrimmed' });
-      // });
     });
 
     describe('updateQuery()', () => {
+      it('should return a batch action with RESET_PAGE', () => {
+        const query = 'rambo';
+        stub(Selectors, 'query');
+        stub(utils, 'action');
+        actions.resetPage = (): any => ACTION;
+
+        const batchAction = actions.updateQuery(query);
+
+        expect(batchAction[0]).to.eql(ACTION)
+      });
+
       it('should return an action', () => {
         const query = 'rambo';
-        stub(Selectors, 'query').returns('blueberry');
+        stub(Selectors, 'query');
 
-        expectAction(() => actions.updateQuery(query), Actions.UPDATE_QUERY, query,
+        expectAction(() => actions.updateQuery(query)[1], Actions.UPDATE_QUERY, query,
           (meta) => {
             expect(meta.validator.payload[0].func(query)).to.be.true;
             return expect(meta.validator.payload[1].func(query)).to.be.true;
@@ -247,7 +213,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
       it('should not return an action when query is invalid', () => {
         const query = '';
 
-        expectAction(() => actions.updateQuery(query), Actions.UPDATE_QUERY, query,
+        expectAction(() => actions.updateQuery(query)[1], Actions.UPDATE_QUERY, query,
           (meta) => expect(meta.validator.payload[0].func(query)).to.be.false);
       });
 
@@ -255,30 +221,40 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const query = 'umbrella';
         stub(Selectors, 'query').returns(query);
 
-        expectAction(() => actions.updateQuery(query), Actions.UPDATE_QUERY, query,
+        expectAction(() => actions.updateQuery(query)[1], Actions.UPDATE_QUERY, query,
           (meta) => expect(meta.validator.payload[1].func(query)).to.be.false);
       });
     });
 
     describe('resetRefinements()', () => {
+      it('should return a batch action with RESET_PAGE', () => {
+        const field = 'brand';
+        actions.resetPage = (): any => ACTION;
+        stub(utils, 'action');
+
+        const batchAction = actions.resetRefinements(field);
+
+        expect(batchAction[0]).to.eq(ACTION);
+      });
+
       it('should return an action', () => {
         const field = 'brand';
 
-        expectAction(() => actions.resetRefinements(field), Actions.RESET_REFINEMENTS, field,
+        expectAction(() => actions.resetRefinements(field)[1], Actions.RESET_REFINEMENTS, field,
           (meta) => expect(meta.validator.payload[0].func()).to.be.true);
       });
 
       it('should not return an action when field is invalid', () => {
         const field = false;
 
-        expectAction(() => actions.resetRefinements(field), Actions.RESET_REFINEMENTS, field,
+        expectAction(() => actions.resetRefinements(field)[1], Actions.RESET_REFINEMENTS, field,
           (meta) => expect(meta.validator.payload[0].func()).to.be.false);
       });
 
       it('should not return an action when no refinements selected', () => {
         stub(Selectors, 'selectedRefinements').returns([]);
 
-        expectAction(() => actions.resetRefinements(), Actions.RESET_REFINEMENTS, undefined,
+        expectAction(() => actions.resetRefinements()[1], Actions.RESET_REFINEMENTS, undefined,
           (meta) => expect(meta.validator.payload[1].func()).to.be.false);
       });
 
@@ -287,7 +263,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         stub(Selectors, 'selectedRefinements').returns([{}]);
         stub(Selectors, 'navigation').returns({ selected: [] });
 
-        expectAction(() => actions.resetRefinements(field), Actions.RESET_REFINEMENTS, field,
+        expectAction(() => actions.resetRefinements(field)[1], Actions.RESET_REFINEMENTS, field,
           (meta) => expect(meta.validator.payload[2].func()).to.be.false);
       });
     });
@@ -313,11 +289,24 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
       const refinement = { c: 'd' };
       const rangeRefinement = { range: true };
 
+      it('should return a batch action with RESET_PAGE', () => {
+        const value = 'a';
+        const resetPageAction = { a: 'b' };
+        stub(utils, 'refinementPayload').returns(refinement);
+        stub(utils, 'action');
+        actions.resetPage = spy(() => resetPageAction);
+
+        const batchAction = actions.addRefinement(navigationId, value);
+
+        expect(batchAction[0]).to.eql(resetPageAction);
+      });
+
       it('should return an action with value refinement', () => {
         const value = 'a';
         const refinementPayload = stub(utils, 'refinementPayload').returns(refinement);
+        actions.resetPage = spy();
 
-        expectAction(() => actions.addRefinement(navigationId, value), Actions.ADD_REFINEMENT, refinement);
+        expectAction(() => actions.addRefinement(navigationId, value)[1], Actions.ADD_REFINEMENT, refinement);
         expect(refinementPayload).to.be.calledWithExactly(navigationId, value, null);
       });
 
@@ -325,36 +314,41 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const low = 2;
         const high = 4;
         const refinementPayload = stub(utils, 'refinementPayload').returns(refinement);
+        actions.resetPage = spy();
 
-        expectAction(() => actions.addRefinement(navigationId, low, high), Actions.ADD_REFINEMENT, refinement);
+        expectAction(() => actions.addRefinement(navigationId, low, high)[1], Actions.ADD_REFINEMENT, refinement);
         expect(refinementPayload).to.be.calledWithExactly(navigationId, low, high);
       });
 
       it('should validate navigationId', () => {
         stub(utils, 'refinementPayload').returns(refinement);
+        actions.resetPage = spy();
 
-        expectAction(() => actions.addRefinement(null, null), Actions.ADD_REFINEMENT, refinement,
+        expectAction(() => actions.addRefinement(null, null)[1], Actions.ADD_REFINEMENT, refinement,
           (meta) => expect(meta.validator.navigationId).to.eq(validators.isString));
       });
 
       it('should invalidate non-numeric low value', () => {
         stub(utils, 'refinementPayload').returns(rangeRefinement);
+        actions.resetPage = spy();
 
-        expectAction(() => actions.addRefinement(null, 'g'), Actions.ADD_REFINEMENT, rangeRefinement,
+        expectAction(() => actions.addRefinement(null, 'g')[1], Actions.ADD_REFINEMENT, rangeRefinement,
           (meta) => expect(meta.validator.payload[0].func(rangeRefinement)).to.be.false);
       });
 
       it('should invalidate non-numeric high value', () => {
         stub(utils, 'refinementPayload').returns(rangeRefinement);
+        actions.resetPage = spy();
 
-        expectAction(() => actions.addRefinement(null, 2, 'j'), Actions.ADD_REFINEMENT, rangeRefinement,
+        expectAction(() => actions.addRefinement(null, 2, 'j')[1], Actions.ADD_REFINEMENT, rangeRefinement,
           (meta) => expect(meta.validator.payload[0].func(rangeRefinement)).to.be.false);
       });
 
       it('should invalidate low greater than high', () => {
         stub(utils, 'refinementPayload').returns(rangeRefinement);
+        actions.resetPage = spy();
 
-        expectAction(() => actions.addRefinement(null, 2, 1), Actions.ADD_REFINEMENT, rangeRefinement,
+        expectAction(() => actions.addRefinement(null, 2, 1)[1], Actions.ADD_REFINEMENT, rangeRefinement,
           (meta) => expect(meta.validator.payload[1].func(rangeRefinement)).to.be.false);
       });
 
@@ -362,8 +356,9 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const value = 7;
         const isStringValidator = stub(validators.isString, 'func').returns(false);
         stub(utils, 'refinementPayload').returns(refinement);
+        actions.resetPage = spy();
 
-        expectAction(() => actions.addRefinement(null, value), Actions.ADD_REFINEMENT, refinement,
+        expectAction(() => actions.addRefinement(null, value)[1], Actions.ADD_REFINEMENT, refinement,
           (meta) => expect(meta.validator.payload[2].func(refinement)).to.be.false);
         expect(isStringValidator).to.be.calledWith(value);
       });
@@ -372,8 +367,9 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const state = { a: 'b' };
         const selectNavigation = stub(Selectors, 'navigation');
         stub(utils, 'refinementPayload').returns(refinement);
+        actions.resetPage = spy();
 
-        expectAction(() => actions.addRefinement(navigationId, null), Actions.ADD_REFINEMENT, refinement,
+        expectAction(() => actions.addRefinement(navigationId, null)[1], Actions.ADD_REFINEMENT, refinement,
           (meta) => expect(meta.validator.payload[3].func(null, state)).to.be.true);
         expect(selectNavigation).to.be.calledWithExactly(state, navigationId);
       });
@@ -384,8 +380,9 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const refinementsMatch = stub(SearchAdapter, 'refinementsMatch').returns(true);
         stub(utils, 'refinementPayload').returns(refinement);
         stub(Selectors, 'navigation').returns({ selected: [1], refinements: [{}, selected, {}] });
+        actions.resetPage = spy();
 
-        expectAction(() => actions.addRefinement(null, value), Actions.ADD_REFINEMENT, refinement,
+        expectAction(() => actions.addRefinement(null, value)[1], Actions.ADD_REFINEMENT, refinement,
           (meta) => expect(meta.validator.payload[3].func(refinement)).to.be.false);
         expect(refinementsMatch).to.be.calledWithExactly(refinement, selected, 'Value');
       });
@@ -396,8 +393,9 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const refinementsMatch = stub(SearchAdapter, 'refinementsMatch').returns(true);
         stub(utils, 'refinementPayload').returns(refinement);
         stub(Selectors, 'navigation').returns({ range: true, selected: [1], refinements: [{}, selected, {}] });
+        actions.resetPage = spy();
 
-        expectAction(() => actions.addRefinement(null, value), Actions.ADD_REFINEMENT, refinement,
+        expectAction(() => actions.addRefinement(null, value)[1], Actions.ADD_REFINEMENT, refinement,
           (meta) => expect(meta.validator.payload[3].func(refinement)).to.be.false);
         expect(refinementsMatch).to.be.calledWithExactly(refinement, selected, 'Range');
       });
@@ -488,45 +486,73 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
     });
 
     describe('resetRecall()', () => {
-      it('should call actions.updateSearch() with falsey params to clear request state', () => {
-        const updateSearch = actions.updateSearch = spy();
+      const resetPageAction = { a: 'b' };
+      const resetRefinementsAction = { c: 'd' };
+      const updateQueryAction = { e: 'f' };
 
-        actions.resetRecall();
+      it('should return bulk action with RESET_PAGE, RESET_REFINEMENTS and UPDATE_QUERY', () => {
+        const resetRefinements = actions.resetRefinements = spy(() => resetRefinementsAction);
+        const updateQuery = actions.updateQuery = spy(() => updateQueryAction);
+        actions.resetPage = (): any => resetPageAction;
 
-        // tslint:disable-next-line max-line-length
-        expect(updateSearch).to.be.calledWithExactly({ query: null, navigationId: undefined, index: undefined, clear: true });
+        const batchAction = actions.resetRecall();
+
+        expect(batchAction).to.eql([resetPageAction, resetRefinementsAction, updateQueryAction]);
+        expect(resetRefinements).to.be.calledWithExactly(true);
+        expect(updateQuery).to.be.calledWithExactly(null);
       });
 
-      it('should call actions.updateSearch() with a query', () => {
-        const query = 'pineapple';
-        const updateSearch = actions.updateSearch = spy();
+      it('should UPDATE_QUERY from query', () => {
+        const query = 'basketball';
+        const updateQuery = actions.updateQuery = spy();
+        actions.resetRefinements = () => null;
+        actions.resetPage = () => null;
 
         actions.resetRecall(query);
 
-        expect(updateSearch).to.be.calledWithExactly({ query, navigationId: undefined, index: undefined, clear: true });
+        expect(updateQuery).to.be.calledWithExactly(query);
       });
 
-      it('should call actions.updateSearch() with a query and refinement', () => {
-        const query = 'pineapple';
-        const navigationId = 'brand';
-        const index = 9;
-        const updateSearch = actions.updateSearch = spy();
+      it('should return bulk action with SELECT_REFINEMENT if field and index provided', () => {
+        const field = 'color';
+        const index = 8;
+        const selectRefinementAction = { g: 'h' };
+        const selectRefinement = actions.selectRefinement = spy(() => [selectRefinementAction]);
+        actions.resetRefinements = (): any => [resetRefinementsAction];
+        actions.updateQuery = (): any => [updateQueryAction];
+        actions.resetPage = (): any => resetPageAction;
 
-        actions.resetRecall(query, { field: navigationId, index });
+        const batchAction = actions.resetRecall('', { field, index });
 
-        expect(updateSearch).to.be.calledWithExactly({ query, navigationId, index, clear: true });
+        expect(batchAction).to.eql([
+          resetPageAction,
+          resetRefinementsAction,
+          updateQueryAction,
+          selectRefinementAction
+        ]);
+        expect(selectRefinement).to.be.calledWithExactly(field, index);
       });
     });
 
     describe('selectRefinement()', () => {
-      it('should return an action', () => {
+      it('should return a batch action with RESET_PAGE', () => {
+        const isRefinementDeselected = stub(Selectors, 'isRefinementDeselected').returns(true);
+        stub(utils, 'action');
+        actions.resetPage = (): any => ACTION;
+
+        const batchAction = actions.selectRefinement('', 0);
+
+        expect(batchAction[0]).to.eq(ACTION);
+      });
+
+      it('should return a batch action', () => {
         const isRefinementDeselected = stub(Selectors, 'isRefinementDeselected').returns(true);
         const navigationId = 'colour';
         const index = 30;
         const state = { a: 'b' };
 
         // tslint:disable-next-line max-line-length
-        expectAction(() => actions.selectRefinement(navigationId, index), Actions.SELECT_REFINEMENT, { navigationId, index },
+        expectAction(() => actions.selectRefinement(navigationId, index)[1], Actions.SELECT_REFINEMENT, { navigationId, index },
           (meta) => {
             expect(meta.validator.payload.func(null, state)).to.be.true;
             return expect(isRefinementDeselected).to.be.calledWithExactly(state, navigationId, index);
@@ -537,19 +563,29 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         stub(Selectors, 'isRefinementDeselected').returns(false);
 
         // tslint:disable-next-line max-line-length
-        expectAction(() => actions.selectRefinement('colour', 30), Actions.SELECT_REFINEMENT, { navigationId: 'colour', index: 30 },
+        expectAction(() => actions.selectRefinement('colour', 30)[1], Actions.SELECT_REFINEMENT, { navigationId: 'colour', index: 30 },
           (meta) => expect(meta.validator.payload.func(null, {})).to.be.false);
       });
 
       describe('deselectRefinement()', () => {
-        it('should return an action', () => {
+        it('should return a batch action with RESET_PAGE', () => {
+          const isRefinementDeselected = stub(Selectors, 'isRefinementDeselected').returns(true);
+          stub(utils, 'action');
+          actions.resetPage = (): any => ACTION;
+
+          const batchAction = actions.deselectRefinement('', 0);
+
+          expect(batchAction[0]).to.eq(ACTION);
+        });
+
+        it('should return a batch action', () => {
           const isRefinementSelected = stub(Selectors, 'isRefinementSelected').returns(true);
           const navigationId = 'colour';
           const index = 30;
           const state = { a: 'b' };
 
           // tslint:disable-next-line max-line-length
-          expectAction(() => actions.deselectRefinement(navigationId, index), Actions.DESELECT_REFINEMENT, { navigationId, index },
+          expectAction(() => actions.deselectRefinement(navigationId, index)[1], Actions.DESELECT_REFINEMENT, { navigationId, index },
             (meta) => {
               expect(meta.validator.payload.func(null, state)).to.be.true;
               return expect(isRefinementSelected).to.be.calledWithExactly(state, navigationId, index);
@@ -560,7 +596,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
           stub(Selectors, 'isRefinementSelected').returns(false);
 
           // tslint:disable-next-line max-line-length
-          expectAction(() => actions.deselectRefinement('colour', 30), Actions.DESELECT_REFINEMENT, { navigationId: 'colour', index: 30 },
+          expectAction(() => actions.deselectRefinement('colour', 30)[1], Actions.DESELECT_REFINEMENT, { navigationId: 'colour', index: 30 },
             (meta) => expect(meta.validator.payload.func(null, {})).to.be.false);
         });
       });

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -133,7 +133,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
 
       it('should return a bulk action with UPDATE_QUERY', () => {
         const query = 'q';
-        const updateQuery = actions.updateQuery = spy(() => [ACTION]);
+        const updateQuery = stub(actions, 'updateQuery').returns([ACTION]);
 
         const batchAction = actions.updateSearch({ query });
 
@@ -143,18 +143,19 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
 
       it('should return a bulk action with RESET_REFINEMENTS', () => {
         const clear = 'q';
-        const checkAndResetRefinements = actions.checkAndResetRefinements = spy(() => [ACTION]);
+        const shouldResetRefinements = stub(actions, 'shouldResetRefinements').returns(true);
+        const resetRefinements = stub(actions, 'resetRefinements').returns([ACTION]);
 
         const batchAction = actions.updateSearch({ clear });
 
         expect(batchAction).to.eql([resetPageAction, ACTION]);
-        expect(checkAndResetRefinements).to.be.calledWithExactly({ clear });
+        expect(shouldResetRefinements).to.be.calledWithExactly({ clear });
       });
 
       it('should return a bulk action with SELECT_REFINEMENT', () => {
         const navigationId = 'color';
         const index = 4;
-        const selectRefinement = actions.selectRefinement = spy(() => [ACTION]);
+        const selectRefinement = stub(actions, 'selectRefinement').returns([ACTION]);
 
         const batchAction = actions.updateSearch({ navigationId, index });
 
@@ -165,7 +166,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
       it('should return a bulk action with value ADD_REFINEMENT', () => {
         const navigationId = 'color';
         const value = 'blue';
-        const addRefinement = actions.addRefinement = spy(() => [ACTION]);
+        const addRefinement = stub(actions, 'addRefinement').returns([ACTION]);
 
         const batchAction = actions.updateSearch({ navigationId, value });
 
@@ -178,7 +179,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const range = true;
         const low = 1;
         const high = 2;
-        const addRefinement = actions.addRefinement = spy(() => [ACTION]);
+        const addRefinement = stub(actions, 'addRefinement').returns([ACTION]);
 
         const batchAction = actions.updateSearch({ navigationId, range, low, high });
 
@@ -193,56 +194,46 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
       });
     });
 
-    describe('checkAndResetRefinements()', () => {
+    describe('shouldResetRefinements()', () => {
       it('should call RESET_REFINEMENTS if refinementsMatch is false', () => {
-        const resetRefinements = stub(actions, 'resetRefinements');
         stub(Selectors, 'selectedRefinements').returns(['hello']);
         stub(SearchAdapter, 'refinementsMatch').returns(false);
 
         flux.store = { getState: () => [] };
-        actions.checkAndResetRefinements({ navigationId: 'truthy' });
-        expect(resetRefinements).to.be.calledOnce;
+        expect(actions.shouldResetRefinements({ navigationId: 'truthy' })).to.be.true;
       });
 
       it('should call RESET_REFINEMENTS if currentRefinements length is not 1', () => {
-        const resetRefinements = stub(actions, 'resetRefinements');
         stub(Selectors, 'selectedRefinements').returns(['hello', 'hello']);
         stub(SearchAdapter, 'refinementsMatch').returns(true);
 
         flux.store = { getState: () => [] };
-        actions.checkAndResetRefinements({ navigationId: 'truthy' });
-        expect(resetRefinements).to.be.calledOnce;
+        expect(actions.shouldResetRefinements({ navigationId: 'truthy' })).to.be.true;
       });
 
       it('should call RESET_REFINEMENTS if navigationId is falsy', () => {
-        const resetRefinements = stub(actions, 'resetRefinements');
         stub(Selectors, 'selectedRefinements').returns(['hello']);
         stub(SearchAdapter, 'refinementsMatch').returns(true);
 
         flux.store = { getState: () => [] };
         // undefined is falsy
-        actions.checkAndResetRefinements({ navigationId: undefined });
-        expect(resetRefinements).to.be.calledOnce;
+        expect(actions.shouldResetRefinements({ navigationId: undefined })).to.be.true;
       });
 
       it('should return [] all above conditions are false', () => {
-        const resetRefinements = stub(actions, 'resetRefinements');
         stub(Selectors, 'selectedRefinements').returns(['hello']);
         stub(SearchAdapter, 'refinementsMatch').returns(true);
 
         flux.store = { getState: () => [] };
-        let result = actions.checkAndResetRefinements({ navigationId: 'truthy' });
-        expect(result).to.be.eql([]);
+        expect(actions.shouldResetRefinements({ navigationId: 'truthy' })).to.be.false;
       });
 
       it('should return [] all above conditions are false (range is truthy case)', () => {
-        const resetRefinements = stub(actions, 'resetRefinements');
         stub(Selectors, 'selectedRefinements').returns(['hello']);
         stub(SearchAdapter, 'refinementsMatch').returns(true);
 
         flux.store = { getState: () => [] };
-        let result = actions.checkAndResetRefinements({ navigationId: 'truthy', range: true });
-        expect(result).to.be.eql([]);
+        expect(actions.shouldResetRefinements({ navigationId: 'truthy', range: true })).to.be.false;
       });
     });
 
@@ -353,7 +344,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const resetPageAction = { a: 'b' };
         stub(utils, 'refinementPayload').returns(refinement);
         stub(utils, 'action');
-        actions.resetPage = spy(() => resetPageAction);
+        stub(actions, 'resetPage').returns(resetPageAction);
 
         const batchAction = actions.addRefinement(navigationId, value);
 
@@ -563,7 +554,7 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const field = 'color';
         const index = 8;
         const selectRefinementAction = { g: 'h' };
-        const selectRefinement = actions.selectRefinement = spy(() => [selectRefinementAction]);
+        const selectRefinement = stub(actions, 'selectRefinement').returns([selectRefinementAction]);
         const search = stub(actions, 'search').returns([
           resetPageAction,
           resetRefinementsAction,
@@ -806,12 +797,12 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const extractRecordCount = stub(SearchAdapter, 'extractRecordCount').returns(recordCount);
         const extractProducts = stub(SearchAdapter, 'extractProducts').returns(products);
         const selectCollection = stub(Selectors, 'collection').returns(collection);
-        const receiveQuery = actions.receiveQuery = spy(() => receiveQueryAction);
-        const receiveProductRecords = actions.receiveProductRecords = spy(() => receiveProductRecordsAction);
+        const receiveQuery = stub(actions, 'receiveQuery').returns(receiveQueryAction);
+        const receiveProductRecords = stub(actions, 'receiveProductRecords').returns(receiveProductRecordsAction);
         const receiveNavigations = actions.receiveNavigations = spy(() => receiveNavigationsAction);
-        const receiveRecordCount = actions.receiveRecordCount = spy(() => receiveRecordCountAction);
+        const receiveRecordCount = stub(actions, 'receiveRecordCount').returns(receiveRecordCountAction);
         const receiveCollectionCount = actions.receiveCollectionCount = spy(() => receiveCollectionCountAction);
-        const receivePage = actions.receivePage = spy(() => receivePageAction);
+        const receivePage = stub(actions, 'receivePage').returns(receivePageAction);
         const receiveTemplate = actions.receiveTemplate = spy(() => receiveTemplateAction);
         flux.store = { getState: () => state };
 
@@ -968,8 +959,8 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const extractProducts = stub(SearchAdapter, 'extractProducts').returns(products);
         const extractTemplate = stub(SearchAdapter, 'extractTemplate').returns(template);
         // tslint:disable-next-line max-line-length
-        const receiveAutocompleteProductRecords = actions.receiveAutocompleteProductRecords = spy(() => receiveAutocompleteProductRecordsAction);
-        const receiveAutocompleteTemplate = actions.receiveAutocompleteTemplate = spy(() => receiveAutocompleteTemplateAction);
+        const receiveAutocompleteProductRecords = stub(actions, 'receiveAutocompleteProductRecords').returns(receiveAutocompleteProductRecordsAction);
+        const receiveAutocompleteTemplate = stub(actions, 'receiveAutocompleteTemplate').returns(receiveAutocompleteTemplateAction);
 
         const batchAction = actions.receiveAutocompleteProducts(response);
 

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -408,15 +408,23 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
 
       it('should clear the refinements and add a value refinement', () => {
         const value = 'a';
-        const action = { a: 'b' };
-        const updateSearch = stub(actions, 'updateSearch').returns(action);
-        const refinementPayload = stub(utils, 'refinementPayload').returns({ c: 'd' });
+        const resetRefinementsReturn = 'reset';
+        const addRefinementReturn = 'add';
+        const resetPageReturn = 'page';
+
+        const resetRefinements = stub(actions, 'resetRefinements').returns(resetRefinementsReturn);
+        const addRefinement = stub(actions, 'addRefinement').returns(addRefinementReturn);
+        stub(actions, 'resetPage').returns(resetPageReturn);
 
         const result = actions.switchRefinement(navigationId, value);
 
-        expect(result).to.be.eq(action);
-        expect(updateSearch).to.be.calledWithExactly({ c: 'd', clear: navigationId });
-        expect(refinementPayload).to.be.calledWithExactly(navigationId, value, null);
+        expect(result).to.be.eql([
+          resetPageReturn,
+          resetRefinementsReturn,
+          addRefinementReturn
+        ]);
+        expect(resetRefinements).to.be.calledWithExactly(navigationId);
+        expect(addRefinement).to.be.calledWithExactly(navigationId, value, null);
       });
 
       it('should clear the refinements and add a range refinement', () => {
@@ -434,24 +442,48 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
     describe('search()', () => {
       it('should call actions.updateSearch()', () => {
         const query = 'pineapple';
-        const updateSearch = actions.updateSearch = spy();
 
-        actions.search(query);
+        const resetRefinementsReturn = 'reset';
+        const updateReturn = 'update';
+        const resetPageReturn = 'page';
 
-        expect(updateSearch).to.be.calledWithExactly({ query, clear: true });
+        const resetRefinements = stub(actions, 'resetRefinements').returns(resetRefinementsReturn);
+        const updateQuery = stub(actions, 'updateQuery').returns(updateReturn);
+        stub(actions, 'resetPage').returns(resetPageReturn);
+
+        const result = actions.search(query);
+
+        expect(result).to.be.eql([
+          resetPageReturn,
+          resetRefinementsReturn,
+          updateReturn,
+        ]);
+        expect(resetRefinements).to.be.calledWithExactly(true);
+        expect(updateQuery).to.be.calledWithExactly(query);
       });
 
       it('should fall back to current query', () => {
         const query = 'pineapple';
-        const state = { a: 'b' };
-        const updateSearch = actions.updateSearch = spy();
-        const selectQuery = stub(Selectors, 'query').returns(query);
-        flux.store = { getState: () => state };
 
-        actions.search();
+        const resetRefinementsReturn = 'reset';
+        const updateReturn = 'update';
+        const resetPageReturn = 'page';
 
-        expect(updateSearch).to.be.calledWithExactly({ query, clear: true });
-        expect(selectQuery).to.be.calledWithExactly(state);
+        const resetRefinements = stub(actions, 'resetRefinements').returns(resetRefinementsReturn);
+        const updateQuery = stub(actions, 'updateQuery').returns(updateReturn);
+        const queryStub = stub(Selectors, 'query').returns(query);
+        stub(actions, 'resetPage').returns(resetPageReturn);
+        flux.store = { getState: () => null };
+
+        const result = actions.search();
+
+        expect(result).to.be.eql([
+          resetPageReturn,
+          resetRefinementsReturn,
+          updateReturn,
+        ]);
+        expect(resetRefinements).to.be.calledWithExactly(true);
+        expect(updateQuery).to.be.calledWithExactly(query);
       });
     });
 

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -162,6 +162,30 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         expect(selectRefinement).to.be.calledWithExactly(navigationId, index);
       });
 
+      it('should return a bulk action with value ADD_REFINEMENT', () => {
+        const navigationId = 'color';
+        const value = 'blue';
+        const addRefinement = actions.addRefinement = spy(() => ACTION);
+
+        const batchAction = actions.updateSearch({ navigationId, value });
+
+        expect(batchAction).to.eql([resetPageAction, ACTION]);
+        expect(addRefinement).to.be.calledWithExactly(navigationId, value);
+      });
+
+      it('should return a bulk action with range ADD_REFINEMENT', () => {
+        const navigationId = 'color';
+        const range = true;
+        const low = 1;
+        const high = 2;
+        const addRefinement = actions.addRefinement = spy(() => ACTION);
+
+        const batchAction = actions.updateSearch({ navigationId, range, low, high });
+
+        expect(batchAction).to.eql([resetPageAction, ACTION]);
+        expect(addRefinement).to.be.calledWithExactly(navigationId, low, high);
+      });
+
       // it('should return an action with validation if search does not contain query', () => {
       //   const search: any = { a: 'b' };
       //

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -130,6 +130,16 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         expect(updateQuery).to.be.calledWithExactly(query);
       });
 
+      it('should return an action with validation if search contains clear', () => {
+        const clear = 'q';
+        const resetRefinements = actions.resetRefinements = spy(() => ACTION);
+
+        const actualActions = actions.updateSearch({ clear });
+
+        expect(actualActions).to.eql([ACTION]);
+        expect(resetRefinements).to.be.calledWithExactly(clear);
+      });
+
       // it('should return an action with validation if search does not contain query', () => {
       //   const search: any = { a: 'b' };
       //
@@ -181,6 +191,24 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         const query = 'rambo';
 
         expectAction(() => actions.updateQuery(query), Actions.UPDATE_QUERY, query);
+      });
+    });
+
+    describe('resetRefinements()', () => {
+      it('should return an action', () => {
+        const field = 'rambo';
+
+        expectAction(() => actions.resetRefinements(field), Actions.RESET_REFINEMENTS, field, (meta) => {
+          return expect(meta.validator.payload.func()).to.be.true;
+        });
+      });
+
+      it('should not return an action', () => {
+        const field = false;
+
+        expectAction(() => actions.resetRefinements(field), Actions.RESET_REFINEMENTS, field, (meta) => {
+          return expect(meta.validator.payload.func()).to.be.false;
+        });
       });
     });
 
@@ -238,18 +266,6 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
         actions.switchRefinement(navigationId, low, high);
 
         expect(refinementPayload).to.be.calledWithExactly(navigationId, low, high);
-      });
-    });
-
-    describe('resetRefinements()', () => {
-      it('should reset refinements', () => {
-        const action = { a: 'b' };
-        const updateSearch = stub(actions, 'updateSearch').returns(action);
-
-        const result = actions.resetRefinements();
-
-        expect(result).to.be.eq(action);
-        expect(updateSearch).to.be.calledWithExactly({ clear: true });
       });
     });
 

--- a/test/unit/core/action-creator.ts
+++ b/test/unit/core/action-creator.ts
@@ -212,6 +212,14 @@ suite('ActionCreator', ({ expect, spy, stub }) => {
       });
     });
 
+    describe('resetPage()', () => {
+      it ('should return an action', () => {
+        expectAction(() => actions.resetPage(), Actions.RESET_PAGE, undefined, (meta) => {
+          return expect(meta.validator.payload.func()).to.be.true;
+        });
+      });
+    });
+
     describe('addRefinement()', () => {
       const navigationId = 'book';
 

--- a/test/unit/core/reducers/data/navigations.ts
+++ b/test/unit/core/reducers/data/navigations.ts
@@ -58,42 +58,6 @@ suite('navigations', ({ expect }) => {
       expect(reducer).to.eql(newState);
     });
 
-    // it('should clear and add selected refinement state on UPDATE_SEARCH', () => {
-    //   const newState = {
-    //     allIds,
-    //     byId: {
-    //       Format: {
-    //         ...Format,
-    //         selected: [0],
-    //       },
-    //       Section: {
-    //         ...Section,
-    //         selected: [],
-    //       },
-    //     },
-    //   };
-
-    //   const reducer = navigations(state, {
-    //     type: Actions.UPDATE_SEARCH,
-    //     payload: {
-    //       clear: true,
-    //       navigationId: 'Format',
-    //       index: 0,
-    //     }
-    //   });
-
-    //   expect(reducer).to.eql(newState);
-    // });
-
-    // it('should return state if not clear on UPDATE_SEARCH', () => {
-    //   const reducer = navigations(state, {
-    //     type: Actions.UPDATE_SEARCH,
-    //     payload: { clear: false }
-    //   });
-
-    //   expect(reducer).to.eql(state);
-    // });
-
     it('should update navigations state on RECEIVE_NAVIGATIONS', () => {
       const newNavs = [
         {
@@ -168,18 +132,12 @@ suite('navigations', ({ expect }) => {
       expect(reducer).to.eql(state);
     });
 
-    it('should add value navigation and refinement on UPDATE_SEARCH', () => {
+    it('should add value refinement on ADD_REFINEMENT', () => {
       const newState = {
         allIds: ['Format', 'Section', 'Brand'],
         byId: {
-          Format: {
-            ...Format,
-            selected: []
-          },
-          Section: {
-            ...Section,
-            selected: []
-          },
+          Format,
+          Section,
           Brand: {
             field: 'Brand',
             label: 'Brand',
@@ -191,7 +149,7 @@ suite('navigations', ({ expect }) => {
       };
 
       const reducer = navigations(state, {
-        type: Actions.UPDATE_SEARCH,
+        type: Actions.ADD_REFINEMENT,
         payload: {
           navigationId: 'Brand',
           range: false,
@@ -203,7 +161,7 @@ suite('navigations', ({ expect }) => {
       expect(reducer).to.eql(newState);
     });
 
-    it('should add range navigation and refinement on UPDATE_SEARCH', () => {
+    it('should add range navigation and refinement on ADD_REFINEMENT', () => {
       const newState = {
         allIds: ['Format', 'Section', 'Brand'],
         byId: {
@@ -220,7 +178,7 @@ suite('navigations', ({ expect }) => {
       };
 
       const reducer = navigations(state, {
-        type: Actions.UPDATE_SEARCH,
+        type: Actions.ADD_REFINEMENT,
         payload: {
           navigationId: 'Brand',
           range: true,
@@ -232,7 +190,7 @@ suite('navigations', ({ expect }) => {
       expect(reducer).to.eql(newState);
     });
 
-    it('should add refinement to existing navigation on UPDATE_SEARCH', () => {
+    it('should add refinement to existing navigation on ADD_REFINEMENT', () => {
       const newState = {
         allIds,
         byId: {
@@ -249,41 +207,10 @@ suite('navigations', ({ expect }) => {
       };
 
       const reducer = navigations(state, {
-        type: Actions.UPDATE_SEARCH,
+        type: Actions.ADD_REFINEMENT,
         payload: {
           navigationId: 'Format',
           value: 'eBook'
-        }
-      });
-
-      expect(reducer).to.eql(newState);
-    });
-
-    it('should add refinement and clear extisting refinements on UPDATE_SEARCH', () => {
-      const newState = {
-        allIds,
-        byId: {
-          Section: {
-            ...Section,
-            selected: []
-          },
-          Format: {
-            ...Format,
-            refinements: [
-              ...Format.refinements,
-              { value: 'eBook' }
-            ],
-            selected: [3]
-          }
-        }
-      };
-
-      const reducer = navigations(state, {
-        type: Actions.UPDATE_SEARCH,
-        payload: {
-          navigationId: 'Format',
-          value: 'eBook',
-          clear: true
         }
       });
 
@@ -310,7 +237,7 @@ suite('navigations', ({ expect }) => {
       expect(reducer).to.eql(newState);
     });
 
-    it('should select existing refinement on UPDATE_SEARCH', () => {
+    it('should select existing refinement on ADD_REFINEMENT', () => {
       const newState = {
         allIds,
         byId: {
@@ -323,7 +250,7 @@ suite('navigations', ({ expect }) => {
       };
 
       const reducer = navigations(state, {
-        type: Actions.UPDATE_SEARCH,
+        type: Actions.ADD_REFINEMENT,
         payload: {
           navigationId: 'Format',
           range: false,

--- a/test/unit/core/reducers/data/navigations.ts
+++ b/test/unit/core/reducers/data/navigations.ts
@@ -38,7 +38,7 @@ suite('navigations', ({ expect }) => {
   };
 
   describe('updateNavigations()', () => {
-    it('should clear selected refinements state on UPDATE_SEARCH', () => {
+    it('should clear selected refinements state on RESET_REFINEMENTS', () => {
       const newState = {
         allIds,
         byId: {
@@ -53,46 +53,46 @@ suite('navigations', ({ expect }) => {
         },
       };
 
-      const reducer = navigations(state, { type: Actions.UPDATE_SEARCH, payload: { clear: true } });
+      const reducer = navigations(state, { type: Actions.RESET_REFINEMENTS, payload: true });
 
       expect(reducer).to.eql(newState);
     });
 
-    it('should clear and add selected refinement state on UPDATE_SEARCH', () => {
-      const newState = {
-        allIds,
-        byId: {
-          Format: {
-            ...Format,
-            selected: [0],
-          },
-          Section: {
-            ...Section,
-            selected: [],
-          },
-        },
-      };
+    // it('should clear and add selected refinement state on UPDATE_SEARCH', () => {
+    //   const newState = {
+    //     allIds,
+    //     byId: {
+    //       Format: {
+    //         ...Format,
+    //         selected: [0],
+    //       },
+    //       Section: {
+    //         ...Section,
+    //         selected: [],
+    //       },
+    //     },
+    //   };
 
-      const reducer = navigations(state, {
-        type: Actions.UPDATE_SEARCH,
-        payload: {
-          clear: true,
-          navigationId: 'Format',
-          index: 0,
-        }
-      });
+    //   const reducer = navigations(state, {
+    //     type: Actions.UPDATE_SEARCH,
+    //     payload: {
+    //       clear: true,
+    //       navigationId: 'Format',
+    //       index: 0,
+    //     }
+    //   });
 
-      expect(reducer).to.eql(newState);
-    });
+    //   expect(reducer).to.eql(newState);
+    // });
 
-    it('should return state if not clear on UPDATE_SEARCH', () => {
-      const reducer = navigations(state, {
-        type: Actions.UPDATE_SEARCH,
-        payload: { clear: false }
-      });
+    // it('should return state if not clear on UPDATE_SEARCH', () => {
+    //   const reducer = navigations(state, {
+    //     type: Actions.UPDATE_SEARCH,
+    //     payload: { clear: false }
+    //   });
 
-      expect(reducer).to.eql(state);
-    });
+    //   expect(reducer).to.eql(state);
+    // });
 
     it('should update navigations state on RECEIVE_NAVIGATIONS', () => {
       const newNavs = [
@@ -290,7 +290,7 @@ suite('navigations', ({ expect }) => {
       expect(reducer).to.eql(newState);
     });
 
-    it('should only clear specified navigation on UPDATE_SEARCH', () => {
+    it('should only clear specified navigation on RESET_REFINEMENTS', () => {
       const newState = {
         allIds,
         byId: {
@@ -303,10 +303,8 @@ suite('navigations', ({ expect }) => {
       };
 
       const reducer = navigations(state, {
-        type: Actions.UPDATE_SEARCH,
-        payload: {
-          clear: 'Format'
-        }
+        type: Actions.RESET_REFINEMENTS,
+        payload: 'Format'
       });
 
       expect(reducer).to.eql(newState);
@@ -336,16 +334,16 @@ suite('navigations', ({ expect }) => {
       expect(reducer).to.eql(newState);
     });
 
-    it('should return state on UPDATE_SEARCH if no navigationId and payload clear is falsy', () => {
-      const reducer = navigations(state, {
-        type: Actions.UPDATE_SEARCH,
-        payload: {}
-      });
+    // it('should return state on UPDATE_SEARCH if no navigationId and payload clear is falsy', () => {
+    //   const reducer = navigations(state, {
+    //     type: Actions.UPDATE_SEARCH,
+    //     payload: {}
+    //   });
 
-      expect(reducer).to.eql(state);
-    });
+    //   expect(reducer).to.eql(state);
+    // });
 
-    it('should return state on UPDATE_SEARCH if no navigationId and payload clear is truth', () => {
+    it('should return state on RESET_REFINEMENTS if no navigationId and payload clear is truth', () => {
       const newState = {
         allIds,
         byId: {
@@ -361,8 +359,8 @@ suite('navigations', ({ expect }) => {
       };
 
       const reducer = navigations(state, {
-        type: Actions.UPDATE_SEARCH,
-        payload: { clear: true }
+        type: Actions.RESET_REFINEMENTS,
+        payload: true
       });
 
       expect(reducer).to.eql(newState);

--- a/test/unit/core/reducers/data/navigations.ts
+++ b/test/unit/core/reducers/data/navigations.ts
@@ -27,6 +27,7 @@ suite('navigations', ({ expect }) => {
       { value: 'Gifts', total: 1231 },
       { value: 'Toys', total: 231 },
       { value: 'Teens', total: 193 },
+      { high: 10, low: 5, total: 200 },
     ],
   };
   const state: Store.Indexed<Store.Navigation> = {
@@ -130,6 +131,31 @@ suite('navigations', ({ expect }) => {
       });
 
       expect(reducer).to.eql(state);
+    });
+
+    it('should not add duplicate range refinement on ADD_REFINEMENT', () => {
+      const newState = {
+        ...state,
+        byId: {
+          ...state.byId,
+          Section: {
+            ...Section,
+            selected: [...Section.selected, 4],
+          }
+        }
+      };
+
+      const reducer = navigations(state, {
+        type: Actions.ADD_REFINEMENT,
+        payload: {
+          navigationId: 'Section',
+          range: true,
+          high: 10,
+          low: 5
+        }
+      });
+
+      expect(reducer).to.eql(newState);
     });
 
     it('should add value refinement on ADD_REFINEMENT', () => {

--- a/test/unit/core/reducers/data/navigations.ts
+++ b/test/unit/core/reducers/data/navigations.ts
@@ -287,15 +287,6 @@ suite('navigations', ({ expect }) => {
       expect(reducer).to.eql(newState);
     });
 
-    // it('should return state on UPDATE_SEARCH if no navigationId and payload clear is falsy', () => {
-    //   const reducer = navigations(state, {
-    //     type: Actions.UPDATE_SEARCH,
-    //     payload: {}
-    //   });
-
-    //   expect(reducer).to.eql(state);
-    // });
-
     it('should return state on RESET_REFINEMENTS if no navigationId and payload clear is truth', () => {
       const newState = {
         allIds,

--- a/test/unit/core/reducers/data/page.ts
+++ b/test/unit/core/reducers/data/page.ts
@@ -23,8 +23,8 @@ suite('page', ({ expect }) => {
         current: 1,
       };
 
-      it('UPDATE_SEARCH', () => {
-        const reducer = page(state, { type: Actions.UPDATE_SEARCH });
+      it('RESET_PAGE', () => {
+        const reducer = page(state, { type: Actions.RESET_PAGE });
 
         expect(reducer).to.eql(newState);
       });
@@ -41,21 +41,9 @@ suite('page', ({ expect }) => {
         expect(reducer).to.eql(newState);
       });
 
-      it('SELECT_REFINEMENT', () => {
-        const reducer = page(state, { type: Actions.SELECT_REFINEMENT });
-
-        expect(reducer).to.eql(newState);
-      });
-
-      it('DESELECT_REFINEMENT', () => {
-        const reducer = page(state, { type: Actions.DESELECT_REFINEMENT });
-
-        expect(reducer).to.eql(newState);
-      });
-
       it('should return state if current is already 1', () => {
         state.current = 1;
-        const reducer = page(state, { type: Actions.UPDATE_SEARCH });
+        const reducer = page(state, { type: Actions.RESET_PAGE });
 
         expect(reducer).to.eql(state);
       });

--- a/test/unit/core/reducers/data/query.ts
+++ b/test/unit/core/reducers/data/query.ts
@@ -13,22 +13,16 @@ suite('query', ({ expect }) => {
   };
 
   describe('updateQuery()', () => {
-    it('should update original state on UPDATE_SEARCH if query is in payload', () => {
+    it('should update original state on UPDATE_QUERY if query is in payload', () => {
       const newOriginal = 'potatoes';
       const newState = {
         ...state,
         original: newOriginal,
       };
 
-      const reducer = query(state, { type: Actions.UPDATE_SEARCH, payload: { query: newOriginal } });
+      const reducer = query(state, { type: Actions.UPDATE_QUERY, payload: newOriginal });
 
       expect(reducer).to.eql(newState);
-    });
-
-    it('should update original state on UPDATE_SEARCH if query is not in payload', () => {
-      const reducer = query(state, { type: Actions.UPDATE_SEARCH, payload: {} });
-
-      expect(reducer).to.eql(state);
     });
 
     it('should update state on RECEIVE_QUERY', () => {

--- a/test/unit/core/reducers/ui.ts
+++ b/test/unit/core/reducers/ui.ts
@@ -37,17 +37,10 @@ suite('ui', ({ expect }) => {
       expect(reducer).to.eql(newState);
     });
 
-    it('should clear state on UPDATE_SEARCH when query in payload', () => {
-      const reducer = ui(<any>{ a: 'b' }, { type: Actions.UPDATE_SEARCH, payload: { query: 'eyy' } });
+    it('should clear state when recallId in meta', () => {
+      const reducer = ui(<any>{ a: 'b' }, { type: null, payload: { query: 'eyy' }, meta: { recallId: 'a' } });
 
       expect(reducer).to.eql({});
-    });
-
-    it('should return state on UPDATE_SEARCH when no query in payload', () => {
-      const newState = <any>{ a: 'b' };
-      const reducer = ui(newState, { type: Actions.UPDATE_SEARCH, payload: {} });
-
-      expect(reducer).to.eq(newState);
     });
 
     it('should return state on default', () => {

--- a/test/unit/core/utils.ts
+++ b/test/unit/core/utils.ts
@@ -1,9 +1,12 @@
 import * as utils from '../../../src/core/utils';
 import suite from '../_suite';
+import SearchAdapter from '../../../src/core/adapters/search';
+import Selectors from '../../../src/core/selectors';
+
 
 const ACTION = 'MY_ACTION';
 
-suite('utils', ({ expect, spy }) => {
+suite('utils', ({ expect, spy, stub }) => {
 
   describe('rayify()', () => {
     it('should return an array if the argument is a value', () => {
@@ -62,4 +65,42 @@ suite('utils', ({ expect, spy }) => {
       expect(utils.refinementPayload(navigationId, low, high)).to.eql({ navigationId, low, high, range: true });
     });
   });
+
+      describe('shouldResetRefinements()', () => {
+      it('should be true if refinementsMatch is false', () => {
+        stub(Selectors, 'selectedRefinements').returns(['hello']);
+        stub(SearchAdapter, 'refinementsMatch').returns(false);
+
+        expect(utils.shouldResetRefinements({ navigationId: 'truthy' }, null)).to.be.true;
+      });
+
+      it('should be true if currentRefinements length is not 1', () => {
+        stub(Selectors, 'selectedRefinements').returns(['hello', 'hello']);
+        stub(SearchAdapter, 'refinementsMatch').returns(true);
+
+        expect(utils.shouldResetRefinements({ navigationId: 'truthy' }, null)).to.be.true;
+      });
+
+      it('should be true if navigationId is falsy', () => {
+        stub(Selectors, 'selectedRefinements').returns(['hello']);
+        stub(SearchAdapter, 'refinementsMatch').returns(true);
+
+        // undefined is falsy
+        expect(utils.shouldResetRefinements({ navigationId: undefined }, null)).to.be.true;
+      });
+
+      it('should be false above conditions are false', () => {
+        stub(Selectors, 'selectedRefinements').returns(['hello']);
+        stub(SearchAdapter, 'refinementsMatch').returns(true);
+
+        expect(utils.shouldResetRefinements({ navigationId: 'truthy' }, null)).to.be.false;
+      });
+
+      it('should be false above conditions are false (range is truthy case)', () => {
+        stub(Selectors, 'selectedRefinements').returns(['hello']);
+        stub(SearchAdapter, 'refinementsMatch').returns(true);
+
+        expect(utils.shouldResetRefinements({ navigationId: 'truthy', range: true }, null)).to.be.false;
+      });
+    });
 });

--- a/test/unit/core/validators.ts
+++ b/test/unit/core/validators.ts
@@ -1,0 +1,15 @@
+import * as validators from '../../../src/core/validators';
+import suite from '../_suite';
+
+suite('Validator', ({ expect, spy, stub }) => {
+
+  describe('isString()', () => {
+    const validator = validators.isString;
+    it('should be valid if value is a string', () => {
+      expect(validator.func('test')).to.be.true;
+    });
+    it('should be valid if value is a string', () => {
+      expect(validator.func(<any>false)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Since 712 got cancelled and the fixes happened here this also fixes BBD 712: selecting multiple query + refinements in SAYT fails to update the page.

closes #66 