### PR TITLE
fix(BBD-723): Fix indicies not being checked in shouldResetRefinements

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -48,14 +48,8 @@ export const handleError = (errorAction: Actions.Action<any>,  createAction: () 
 export const shouldResetRefinements =  ({ low, high, value, navigationId, range, index }: Actions.Payload.Search,
                                         state: any): boolean => {
   const currentRefinements = Selectors.selectedRefinements(state);
-  let refinement = { low, high, value };
   // assumes only one refinement can be added at once
-  if (!navigationId || currentRefinements.length !== 1) {
-    return true;
-  }
-
-  if (index) {
-    refinement = Selectors.refinementCrumb(state, navigationId, index);
-  }
-  return !SearchAdapter.refinementsMatch(<any>refinement, currentRefinements[0], range ? 'Range' : 'Value');
+  return (!navigationId || currentRefinements.length !== 1 ||
+          (index && !Selectors.isRefinementSelected(state, navigationId, index)) ||
+          !SearchAdapter.refinementsMatch(<any>{ low, high, value }, currentRefinements[0], range ? 'Range' : 'Value'));
 };

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -45,11 +45,17 @@ export const refinementPayload = (field: string, valueOrLow: any, high: any = nu
 export const handleError = (errorAction: Actions.Action<any>,  createAction: () => any) =>
   errorAction.error ? errorAction :  createAction();
 
-export const shouldResetRefinements =  ({ low, high, value, navigationId, range }: Actions.Payload.Search,
+export const shouldResetRefinements =  ({ low, high, value, navigationId, range, index }: Actions.Payload.Search,
                                         state: any): boolean => {
   const currentRefinements = Selectors.selectedRefinements(state);
-  const refinement = { low, high, value };
+  let refinement = { low, high, value };
   // assumes only one refinement can be added at once
-  return !navigationId || currentRefinements.length !== 1 ||
-    !SearchAdapter.refinementsMatch(<any>refinement, currentRefinements[0], range ? 'Range' : 'Value');
+  if (!navigationId || currentRefinements.length !== 1) {
+    return true;
+  }
+
+  if (index) {
+    refinement = Selectors.refinementCrumb(state, navigationId, index);
+  }
+  return !SearchAdapter.refinementsMatch(<any>refinement, currentRefinements[0], range ? 'Range' : 'Value');
 };

--- a/test/unit/core/utils.ts
+++ b/test/unit/core/utils.ts
@@ -104,11 +104,11 @@ suite('utils', ({ expect, spy, stub }) => {
         });
 
         it('should look up refinement from index if index passed', () => {
-          const crumb = stub(Selectors, 'refinementCrumb').returns({ value: 'hello' });
+          const crumb = stub(Selectors, 'isRefinementSelected').returns(false);
           stub(Selectors, 'selectedRefinements').returns([{ value: 'hello' }]);
 
           expect(utils.shouldResetRefinements(
-            { navigationId: 'truthy', value: 'notHello', index: 4 }, null)).to.be.false;
+            { navigationId: 'truthy', value: 'notHello', index: 4 }, null)).to.be.true;
           expect(crumb).to.be.calledWith(null, 'truthy', 4);
         });
       });

--- a/test/unit/core/utils.ts
+++ b/test/unit/core/utils.ts
@@ -67,40 +67,49 @@ suite('utils', ({ expect, spy, stub }) => {
   });
 
       describe('shouldResetRefinements()', () => {
-      it('should be true if refinementsMatch is false', () => {
-        stub(Selectors, 'selectedRefinements').returns(['hello']);
-        stub(SearchAdapter, 'refinementsMatch').returns(false);
+        it('should be true if refinementsMatch is false', () => {
+          stub(Selectors, 'selectedRefinements').returns(['hello']);
+          stub(SearchAdapter, 'refinementsMatch').returns(false);
 
-        expect(utils.shouldResetRefinements({ navigationId: 'truthy' }, null)).to.be.true;
+          expect(utils.shouldResetRefinements({ navigationId: 'truthy' }, null)).to.be.true;
+        });
+
+        it('should be true if currentRefinements length is not 1', () => {
+          stub(Selectors, 'selectedRefinements').returns(['hello', 'hello']);
+          stub(SearchAdapter, 'refinementsMatch').returns(true);
+
+          expect(utils.shouldResetRefinements({ navigationId: 'truthy' }, null)).to.be.true;
+        });
+
+        it('should be true if navigationId is falsy', () => {
+          stub(Selectors, 'selectedRefinements').returns(['hello']);
+          stub(SearchAdapter, 'refinementsMatch').returns(true);
+
+          // undefined is falsy
+          expect(utils.shouldResetRefinements({ navigationId: undefined }, null)).to.be.true;
+        });
+
+        it('should be false above conditions are false', () => {
+          stub(Selectors, 'selectedRefinements').returns(['hello']);
+          stub(SearchAdapter, 'refinementsMatch').returns(true);
+
+          expect(utils.shouldResetRefinements({ navigationId: 'truthy' }, null)).to.be.false;
+        });
+
+        it('should be false above conditions are false (range is truthy case)', () => {
+          stub(Selectors, 'selectedRefinements').returns(['hello']);
+          stub(SearchAdapter, 'refinementsMatch').returns(true);
+
+          expect(utils.shouldResetRefinements({ navigationId: 'truthy', range: true }, null)).to.be.false;
+        });
+
+        it('should look up refinement from index if index passed', () => {
+          const crumb = stub(Selectors, 'refinementCrumb').returns({ value: 'hello' });
+          stub(Selectors, 'selectedRefinements').returns([{ value: 'hello' }]);
+
+          expect(utils.shouldResetRefinements(
+            { navigationId: 'truthy', value: 'notHello', index: 4 }, null)).to.be.false;
+          expect(crumb).to.be.calledWith(null, 'truthy', 4);
+        });
       });
-
-      it('should be true if currentRefinements length is not 1', () => {
-        stub(Selectors, 'selectedRefinements').returns(['hello', 'hello']);
-        stub(SearchAdapter, 'refinementsMatch').returns(true);
-
-        expect(utils.shouldResetRefinements({ navigationId: 'truthy' }, null)).to.be.true;
-      });
-
-      it('should be true if navigationId is falsy', () => {
-        stub(Selectors, 'selectedRefinements').returns(['hello']);
-        stub(SearchAdapter, 'refinementsMatch').returns(true);
-
-        // undefined is falsy
-        expect(utils.shouldResetRefinements({ navigationId: undefined }, null)).to.be.true;
-      });
-
-      it('should be false above conditions are false', () => {
-        stub(Selectors, 'selectedRefinements').returns(['hello']);
-        stub(SearchAdapter, 'refinementsMatch').returns(true);
-
-        expect(utils.shouldResetRefinements({ navigationId: 'truthy' }, null)).to.be.false;
-      });
-
-      it('should be false above conditions are false (range is truthy case)', () => {
-        stub(Selectors, 'selectedRefinements').returns(['hello']);
-        stub(SearchAdapter, 'refinementsMatch').returns(true);
-
-        expect(utils.shouldResetRefinements({ navigationId: 'truthy', range: true }, null)).to.be.false;
-      });
-    });
 });


### PR DESCRIPTION
In the previous PR we had forgotten to cover the case where an index was passed in instead of a refinement, but there were no tests covering this case, so I added i and the corresponding tests.