### PR TITLE
Get rid of config in .hound.yml file

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,4 @@
 tslint:
   enabled: true
-  config_file: tslint.json
+  config_file:
 fail_on_violations: true


### PR DESCRIPTION
Removing it from the `.hound.yml` file gets hound-ci to use tslint with no config file set, which uses the tslint.json file which is the closest ancestor.