### PR TITLE
fix(BBD-792): selecting a refinement in autocomplete doesn't clear the current query

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -18,7 +18,7 @@ export const rayify = <T>(arr: T | T[]): T[] => Array.isArray(arr) ? arr : [arr]
 export const action = <P, T extends string, M extends Actions.Metadata | {} = {}>(type: T, payload?: P, meta?: M): Actions.Action<T, P, M | {}> => {
   const builtAction: Actions.Action<T, P, M | {}> = { type, meta: meta || {} };
 
-  if (payload != null) {
+  if (payload !== undefined) {
     builtAction.payload = payload;
     if (payload instanceof Error) {
       builtAction.error = true;


### PR DESCRIPTION
Change check from != null to !== undefined, should be able to pass in null as payload.