### PR TITLE
fix(BBD-792): selecting a refinement in autocomplete doesn't clear the current query 

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -18,7 +18,7 @@ export const rayify = <T>(arr: T | T[]): T[] => Array.isArray(arr) ? arr : [arr]
 export const action = <P, T extends string, M extends Actions.Metadata | {} = {}>(type: T, payload?: P, meta?: M): Actions.Action<T, P, M | {}> => {
   const builtAction: Actions.Action<T, P, M | {}> = { type, meta: meta || {} };
 
-  if (payload != null) {
+  if (payload !== undefined) {
     builtAction.payload = payload;
     if (payload instanceof Error) {
       builtAction.error = true;

--- a/test/unit/core/utils.ts
+++ b/test/unit/core/utils.ts
@@ -23,7 +23,7 @@ suite('utils', ({ expect, spy, stub }) => {
   });
 
   describe('action()', () => {
-    it('should build an FSA compliant action with empty meta', () => {
+    it('should build an FSA compliant action with empty meta and no payload when payload is undefined', () => {
       expect(utils.action(ACTION)).to.eql({ type: ACTION, meta: {} });
     });
 
@@ -38,6 +38,12 @@ suite('utils', ({ expect, spy, stub }) => {
       const meta = { e: 'f' };
 
       expect(utils.action(ACTION, payload, meta)).to.eql({ type: ACTION, payload, meta });
+    });
+
+    it('should build an FSA complaint action with payload when payload is null', () => {
+      const payload = null;
+
+      expect(utils.action(ACTION, payload)).to.eql({ type: ACTION, payload, meta: {} });
     });
 
     it('should add error flag if payload is an Error', () => {


### PR DESCRIPTION
Change check from != null to !== undefined, should be able to pass in null as payload.