### PR TITLE
fix(BBD 748): SAYT to include Past Purchase selections

### DIFF
--- a/src/core/actions/index.ts
+++ b/src/core/actions/index.ts
@@ -140,7 +140,7 @@ namespace Actions {
   export type ReceiveOrderHistory = Action<typeof RECEIVE_ORDER_HISTORY, Store.Recommendations.OrderHistoryProduct[]>;
   export const RECEIVE_QUERY_PAST_PURCHASES = 'RECEIVE_QUERY_PAST_PURCHASES';
   // tslint:disable-next-line max-line-length
-  export type ReceiveQueryPastPurchases = Action<typeof RECEIVE_QUERY_PAST_PURCHASES, Store.Product[]>;
+  export type ReceiveQueryPastPurchases = Action<typeof RECEIVE_QUERY_PAST_PURCHASES, Store.ProductWithMetadata[]>;
   export const RECEIVE_NAVIGATION_SORT = 'RECEIVE_NAVIGATION_SORT';
   // tslint:disable-next-line max-line-length
   export type ReceiveNavigationSort = Action<typeof RECEIVE_NAVIGATION_SORT, Store.Recommendations.Navigation[]>;

--- a/src/core/adapters/autocomplete.ts
+++ b/src/core/adapters/autocomplete.ts
@@ -26,11 +26,11 @@ namespace Adapter {
     // tslint:disable-next-line max-line-length
     const categoryValues = hasCategory ? [{ matchAll: true }, ...Adapter.extractCategoryValues(searchTerms[0], category)] : [];
     if (hasCategory) {
-      searchTerms.shift();
+      searchTerms[0].disabled = true;
     }
     return {
       categoryValues,
-      suggestions: searchTerms.map(({ value }) => ({ value })),
+      suggestions: searchTerms.map(({ value, disabled }) => ({ value, disabled })),
       navigations: navigations.map(({ name: field, values: refinements }) =>
         ({ field, label: labels[field] || field, refinements }))
     };

--- a/src/core/adapters/configuration.ts
+++ b/src/core/adapters/configuration.ts
@@ -10,6 +10,22 @@ namespace Adapter {
     ({
       data: <any>{
         present: {
+          fakenews: {
+            results: [
+              {
+                sku: '2470734',
+                quantity: 1
+              },
+              {
+                sku: '1652791',
+                quantity: 1
+              },
+              {
+                sku: '1658063',
+                quantity: 1
+              }
+            ]
+          },
           area: Adapter.extractArea(config, AreaReducer.DEFAULT_AREA),
           autocomplete: {
             suggestions: [],

--- a/src/core/adapters/configuration.ts
+++ b/src/core/adapters/configuration.ts
@@ -10,22 +10,6 @@ namespace Adapter {
     ({
       data: <any>{
         present: {
-          fakenews: {
-            results: [
-              {
-                sku: '2470734',
-                quantity: 1
-              },
-              {
-                sku: '1652791',
-                quantity: 1
-              },
-              {
-                sku: '1658063',
-                quantity: 1
-              }
-            ]
-          },
           area: Adapter.extractArea(config, AreaReducer.DEFAULT_AREA),
           autocomplete: {
             suggestions: [],

--- a/src/core/sagas/autocomplete.ts
+++ b/src/core/sagas/autocomplete.ts
@@ -54,8 +54,7 @@ export namespace Tasks {
         {
           ...autocompleteSuggestions,
           suggestions: Adapter.mergeSuggestions(autocompleteSuggestions.suggestions, yield responses[1].json())
-        } :
-        autocompleteSuggestions;
+        } : autocompleteSuggestions;
 
       yield effects.put(flux.actions.receiveAutocompleteSuggestions(suggestions));
     } catch (e) {

--- a/src/core/store/index.ts
+++ b/src/core/store/index.ts
@@ -212,7 +212,7 @@ namespace Store {
     pastPurchases: {
       products: Recommendations.PastPurchase[];
     };
-    queryPastPurchases: Product[];
+    queryPastPurchases: ProductWithMetadata[];
     orderHistory: any[];
   }
 

--- a/src/flux-capacitor.ts
+++ b/src/flux-capacitor.ts
@@ -126,6 +126,11 @@ class FluxCapacitor extends EventEmitter {
     this.store.dispatch(this.actions.fetchPastPurchases(query));
   }
 
+  pastPurchaseProducts() {
+    this.store.dispatch(this.actions.receiveAutocompleteProductRecords(
+      this.selectors.queryPastPurchases(this.store.getState())));
+  }
+
   /**
    * create instances of all clients used to contact microservices
    */

--- a/test/unit/core/adapters/autocomplete.ts
+++ b/test/unit/core/adapters/autocomplete.ts
@@ -11,7 +11,7 @@ suite('Autocomplete Adapter', ({ expect, stub }) => {
 
       const { suggestions } = Adapter.extractSuggestions(response, '', '', {});
 
-      expect(suggestions).to.eql([{ value: 'a' }, { value: 'b' }]);
+      expect(suggestions).to.eql([{ value: 'a', disabled: undefined }, { value: 'b', disabled: undefined }]);
     });
 
     it('should not extract category values if query does not match', () => {
@@ -72,15 +72,20 @@ suite('Autocomplete Adapter', ({ expect, stub }) => {
       expect(extractCategoryValues.called).to.be.false;
     });
 
-    it ('should shift searchTerms by one element',() => {
-      const searchTerms = ['g', 'r', 'o', 'u', 'p', 'b', 'y'];
+    it ('should set first searchTerms element to disabled',() => {
+      const searchTerms = [{ value: 'g' }, { value: 'r' },
+                           { value: 'o' }, { value: 'u' },
+                           { value: 'p' }, { value: 'b' },
+                           { value: 'y' }];
 
       stub(Adapter, 'termsMatch').returns(true);
       stub(Adapter, 'extractCategoryValues');
 
       Adapter.extractSuggestions({ result: { searchTerms } }, '', 'brand', {});
 
-      expect(searchTerms).to.eql(['r', 'o', 'u', 'p', 'b', 'y']);
+      expect(searchTerms).to.eql([{ value: 'g', disabled: true }, { value: 'r' },
+                                  { value: 'o' }, { value: 'u' }, { value: 'p' },
+                                  { value: 'b' }, { value: 'y' }]);
     });
   });
 

--- a/test/unit/flux-capacitor.ts
+++ b/test/unit/flux-capacitor.ts
@@ -257,6 +257,28 @@ suite('FluxCapacitor', ({ expect, spy, stub }) => {
         expectDispatch(() => flux.saytPastPurchases(query), 'fetchPastPurchases', query);
       });
     });
+
+    describe('pastPurchaseProducts()', () => {
+      it('should call receiveAutocompleteProductRecords() action', () => {
+        const pastPurchases = [1,2,3];
+        const state = 's';
+        const action = 'ac';
+        const queryPastPurchases = spy(() => pastPurchases);
+        const getState = spy(() => state);
+        const dispatch = spy();
+        const receiveAutocompleteProductRecords = spy(() => action);
+
+        flux.store = <any>{ getState, dispatch };
+        flux.actions = <any> { receiveAutocompleteProductRecords };
+        flux.selectors = <any>{ queryPastPurchases };
+
+        flux.pastPurchaseProducts();
+        expect(getState).to.be.calledWithExactly();
+        expect(queryPastPurchases).to.be.calledWithExactly(state);
+        expect(receiveAutocompleteProductRecords).to.be.calledWithExactly(pastPurchases);
+        expect(dispatch).to.be.calledWithExactly(action);
+      });
+    });
   });
 
   describe('static', () => {


### PR DESCRIPTION
Mostly just using what's in BBD-750, also changed product list to have first item set to disabled instead of removed.