### PR TITLE
feat(BBD-857): Add redux devtools extension support

### DIFF
--- a/src/core/store/middleware.ts
+++ b/src/core/store/middleware.ts
@@ -97,7 +97,9 @@ export namespace Middleware {
       middleware.push(require('redux-logger').default);
     }
 
-    return compose(
+    const composeEnhancers = global && global['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'] || compose;
+
+    return composeEnhancers(
       applyMiddleware(thunkEvaluator, saveStateAnalyzer),
       reduxBatch,
       applyMiddleware(...middleware),


### PR DESCRIPTION
Extension here: 

https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd

https://addons.mozilla.org/en-US/firefox/addon/remotedev/ <-- nvm looks like Firefox is currently not working with 57?

Simple 1 line change :)