### PR TITLE
BJs autocomplete categories

### DIFF
--- a/src/core/adapters/autocomplete.ts
+++ b/src/core/adapters/autocomplete.ts
@@ -19,7 +19,8 @@ namespace Adapter {
     Config.extractAutocompleteProductArea(config) || Adapter.extractArea(config);
 
   // tslint:disable-next-line max-line-length
-  export const extractSuggestions = ({ result }: any, query: string, category: string, labels: { [key: string]: string }): Actions.Payload.Autocomplete.Suggestions => {
+  export const extractSuggestions = ({ result }: any, query: string, category: string, labels: { [key: string]: string }, config: Configuration): Actions.Payload.Autocomplete.Suggestions => {
+    console.log("CONFIG:", Config.extractSaytCategoriesForFirstMatch(config) );
     const searchTerms = result.searchTerms || [];
     const navigations = result.navigations || [];
     const hasCategory = category && searchTerms[0] && Adapter.termsMatch(searchTerms[0].value, query);

--- a/src/core/adapters/autocomplete.ts
+++ b/src/core/adapters/autocomplete.ts
@@ -20,12 +20,15 @@ namespace Adapter {
 
   // tslint:disable-next-line max-line-length
   export const extractSuggestions = ({ result }: any, query: string, category: string, labels: { [key: string]: string }, config: Configuration): Actions.Payload.Autocomplete.Suggestions => {
-    console.log("CONFIG:", Config.extractSaytCategoriesForFirstMatch(config) );
     const searchTerms = result.searchTerms || [];
     const navigations = result.navigations || [];
-    const hasCategory = category && searchTerms[0] && Adapter.termsMatch(searchTerms[0].value, query);
+    let hasCategory = category && searchTerms[0] && Adapter.termsMatch(searchTerms[0].value, query);
+    let categoryValues = hasCategory ? [{ matchAll: true }, ...Adapter.extractCategoryValues(searchTerms[0], category)] : [];
+    if( Config.extractSaytCategoriesForFirstMatch(config) ) {
+      hasCategory = category && searchTerms[0];
+      categoryValues = (hasCategory && searchTerms[0].additionalInfo) ? [{ matchAll: true }, ...Adapter.extractCategoryValues(searchTerms[0], category)] : [{ matchAll: true }];
+    }
     // tslint:disable-next-line max-line-length
-    const categoryValues = hasCategory ? [{ matchAll: true }, ...Adapter.extractCategoryValues(searchTerms[0], category)] : [];
     if (hasCategory) {
       searchTerms[0].disabled = true;
     }

--- a/src/core/adapters/autocomplete.ts
+++ b/src/core/adapters/autocomplete.ts
@@ -24,10 +24,14 @@ namespace Adapter {
     const searchTerms = result.searchTerms || [];
     const navigations = result.navigations || [];
     let hasCategory = category && searchTerms[0] && Adapter.termsMatch(searchTerms[0].value, query);
-    let categoryValues = hasCategory ? [{ matchAll: true }, ...Adapter.extractCategoryValues(searchTerms[0], category)] : [];
-    if( Config.extractSaytCategoriesForFirstMatch(config) ) {
+    let categoryValues = hasCategory
+      ? [{ matchAll: true }, ...Adapter.extractCategoryValues(searchTerms[0], category)]
+      : [];
+    if ( Config.extractSaytCategoriesForFirstMatch(config) ) {
       hasCategory = category && searchTerms[0];
-      categoryValues = (hasCategory && searchTerms[0].additionalInfo) ? [{ matchAll: true }, ...Adapter.extractCategoryValues(searchTerms[0], category)] : [{ matchAll: true }];
+      categoryValues = (hasCategory && searchTerms[0].additionalInfo)
+        ? [{ matchAll: true }, ...Adapter.extractCategoryValues(searchTerms[0], category)]
+        : [{ matchAll: true }];
     }
     // tslint:disable-next-line max-line-length
     if (hasCategory) {

--- a/src/core/adapters/autocomplete.ts
+++ b/src/core/adapters/autocomplete.ts
@@ -20,6 +20,7 @@ namespace Adapter {
 
   // tslint:disable-next-line max-line-length
   export const extractSuggestions = ({ result }: any, query: string, category: string, labels: { [key: string]: string }, config: Configuration): Actions.Payload.Autocomplete.Suggestions => {
+
     const searchTerms = result.searchTerms || [];
     const navigations = result.navigations || [];
     let hasCategory = category && searchTerms[0] && Adapter.termsMatch(searchTerms[0].value, query);

--- a/src/core/adapters/autocomplete.ts
+++ b/src/core/adapters/autocomplete.ts
@@ -30,7 +30,7 @@ namespace Adapter {
     }
     return {
       categoryValues,
-      suggestions: searchTerms.map(({ value, disabled }) => ({ value, disabled })),
+      suggestions: searchTerms.map(({ value, disabled, additionalInfo }) => ({ value, disabled, additionalInfo })),
       navigations: navigations.map(({ name: field, values: refinements }) =>
         ({ field, label: labels[field] || field, refinements }))
     };

--- a/src/core/adapters/configuration.ts
+++ b/src/core/adapters/configuration.ts
@@ -138,6 +138,9 @@ namespace Adapter {
   export const extractSaytCategoryField = (config: Configuration) =>
     config.autocomplete.category;
 
+  export const extractSaytCategoriesForFirstMatch = (config: Configuration) =>
+    config.autocomplete.showCategoryValuesForFirstMatch;
+
   export const extractAutocompleteNavigationLabels = (config: Configuration) => {
     return config.autocomplete.navigations;
   };

--- a/src/core/configuration.ts
+++ b/src/core/configuration.ts
@@ -149,6 +149,9 @@ namespace Configuration {
      * number of characters before activating typeahead
      */
     searchCharMinLimit?: number;
+     * whether to use the first term as a category search
+     */
+    showCategoryValuesForFirstMatch?: boolean;
     /**
      * number of suggestions to request
      */

--- a/src/core/configuration.ts
+++ b/src/core/configuration.ts
@@ -149,6 +149,7 @@ namespace Configuration {
      * number of characters before activating typeahead
      */
     searchCharMinLimit?: number;
+    /**
      * whether to use the first term as a category search
      */
     showCategoryValuesForFirstMatch?: boolean;

--- a/src/core/reducers/data/autocomplete.ts
+++ b/src/core/reducers/data/autocomplete.ts
@@ -9,6 +9,7 @@ export type State = Store.Autocomplete;
 
 export const DEFAULTS: State = {
   category: { values: [] },
+  showCategoryValuesForFirstMatch: false,
   products: [],
   navigations: [],
   suggestions: [],

--- a/src/core/sagas/autocomplete.ts
+++ b/src/core/sagas/autocomplete.ts
@@ -50,7 +50,7 @@ export namespace Tasks {
 
       const responses = yield effects.all(requests);
       const navigationLabels = ConfigAdapter.extractAutocompleteNavigationLabels(config);
-      const autocompleteSuggestions = Adapter.extractSuggestions(responses[0], query, field, navigationLabels);
+      const autocompleteSuggestions = Adapter.extractSuggestions(responses[0], query, field, navigationLabels, config);
       const suggestions = recommendationsConfig.suggestionCount > 0 ?
         {
           ...autocompleteSuggestions,

--- a/src/core/store/index.ts
+++ b/src/core/store/index.ts
@@ -332,6 +332,7 @@ namespace Store {
     query?: string; // pre
     suggestions: Autocomplete.Suggestion[]; // post
     category: Autocomplete.Category; // static & post
+    showCategoryValuesForFirstMatch: boolean;
     navigations: Autocomplete.Navigation[]; // post
     products: ProductWithMetadata[]; // post
     template?: Template; // post

--- a/test/unit/core/adapters/autocomplete.ts
+++ b/test/unit/core/adapters/autocomplete.ts
@@ -6,12 +6,14 @@ import suite from '../../_suite';
 suite('Autocomplete Adapter', ({ expect, stub }) => {
 
   describe('extractSuggestions()', () => {
+    const config: any = { autocomplete: { showCategoryValuesForFirstMatch: false } };
+
     it('should remap search term values', () => {
-      const response = { result: { searchTerms: [{ value: 'a' }, { value: 'b', test: 'ignore me' }] } };
+      const response = { result: { searchTerms: [{ value: 'a', additionalInfo: '' }, { value: 'b', additionalInfo: '', test: 'ignore me' }] } };
 
-      const { suggestions } = Adapter.extractSuggestions(response, '', '', {});
+      const { suggestions } = Adapter.extractSuggestions(response, '', '', {}, config);
 
-      expect(suggestions).to.eql([{ value: 'a', disabled: undefined }, { value: 'b', disabled: undefined }]);
+      expect(suggestions).to.eql([{ value: 'a', additionalInfo: '', disabled: undefined }, { value: 'b', additionalInfo: '', disabled: undefined }]);
     });
 
     it('should not extract category values if query does not match', () => {
@@ -22,7 +24,7 @@ suite('Autocomplete Adapter', ({ expect, stub }) => {
       stub(Adapter, 'termsMatch').returns(false);
       stub(Adapter, 'extractCategoryValues').callsFake(() => expect.fail());
 
-      const { categoryValues } = Adapter.extractSuggestions(response, '', 'brand', {});
+      const { categoryValues } = Adapter.extractSuggestions(response, '', 'brand', {}, config);
 
       expect(categoryValues).to.eql([]);
     });
@@ -34,7 +36,7 @@ suite('Autocomplete Adapter', ({ expect, stub }) => {
       const extractCategoryValues = stub(Adapter, 'extractCategoryValues').returns(['x', 'y']);
       stub(Adapter, 'termsMatch').returns(true);
 
-      const { categoryValues } = Adapter.extractSuggestions(response, '', 'brand', {});
+      const { categoryValues } = Adapter.extractSuggestions(response, '', 'brand', {}, config);
 
       expect(categoryValues).to.eql([{matchAll: true}, 'x', 'y']);
       expect(extractCategoryValues).to.be.calledWith(searchTerm);
@@ -46,7 +48,7 @@ suite('Autocomplete Adapter', ({ expect, stub }) => {
       const response = { result: { navigations: [brandNavigation, categoryNavigation] } };
       const labels = { a: 'Brand' };
 
-      const { navigations } = Adapter.extractSuggestions(response, '', 'brand', labels);
+      const { navigations } = Adapter.extractSuggestions(response, '', 'brand', labels, config);
 
       expect(navigations).to.eql([
         { field: 'a', refinements: ['b', 'c'], label: 'Brand' },
@@ -58,7 +60,7 @@ suite('Autocomplete Adapter', ({ expect, stub }) => {
       const response = { result: { searchTerms: [{}] } };
       const extractCategoryValues = stub(Adapter, 'extractCategoryValues');
 
-      Adapter.extractSuggestions(response, '', '', {});
+      Adapter.extractSuggestions(response, '', '', {}, config);
 
       expect(extractCategoryValues.called).to.be.false;
     });
@@ -67,12 +69,12 @@ suite('Autocomplete Adapter', ({ expect, stub }) => {
       const response = { result: { searchTerms: [] } };
       const extractCategoryValues = stub(Adapter, 'extractCategoryValues');
 
-      Adapter.extractSuggestions(response, '', 'brand', {});
+      Adapter.extractSuggestions(response, '', 'brand', {}, config);
 
       expect(extractCategoryValues.called).to.be.false;
     });
 
-    it ('should set first searchTerms element to disabled',() => {
+    it('should set first searchTerms element to disabled',() => {
       const searchTerms = [{ value: 'g' }, { value: 'r' },
                            { value: 'o' }, { value: 'u' },
                            { value: 'p' }, { value: 'b' },
@@ -81,12 +83,14 @@ suite('Autocomplete Adapter', ({ expect, stub }) => {
       stub(Adapter, 'termsMatch').returns(true);
       stub(Adapter, 'extractCategoryValues');
 
-      Adapter.extractSuggestions({ result: { searchTerms } }, '', 'brand', {});
+      Adapter.extractSuggestions({ result: { searchTerms } }, '', 'brand', {}, config);
 
       expect(searchTerms).to.eql([{ value: 'g', disabled: true }, { value: 'r' },
                                   { value: 'o' }, { value: 'u' }, { value: 'p' },
                                   { value: 'b' }, { value: 'y' }]);
     });
+
+    // it
   });
 
   describe('extractCategoryValues()', () => {

--- a/test/unit/core/adapters/autocomplete.ts
+++ b/test/unit/core/adapters/autocomplete.ts
@@ -9,11 +9,15 @@ suite('Autocomplete Adapter', ({ expect, stub }) => {
     const config: any = { autocomplete: { showCategoryValuesForFirstMatch: false } };
 
     it('should remap search term values', () => {
-      const response = { result: { searchTerms: [{ value: 'a', additionalInfo: '' }, { value: 'b', additionalInfo: '', test: 'ignore me' }] } };
+      const searchTerms = [{ value: 'a', additionalInfo: '' }, { value: 'b', additionalInfo: '', test: 'ignore me' }];
+      const response = { result: { searchTerms } };
 
       const { suggestions } = Adapter.extractSuggestions(response, '', '', {}, config);
 
-      expect(suggestions).to.eql([{ value: 'a', additionalInfo: '', disabled: undefined }, { value: 'b', additionalInfo: '', disabled: undefined }]);
+      expect(suggestions).to.eql([
+        { value: 'a', additionalInfo: '', disabled: undefined },
+        { value: 'b', additionalInfo: '', disabled: undefined }
+      ]);
     });
 
     it('should not extract category values if query does not match', () => {

--- a/test/unit/core/adapters/configuration.ts
+++ b/test/unit/core/adapters/configuration.ts
@@ -34,6 +34,7 @@ suite('Configuration Adapter', ({ expect, stub }) => {
                 values: []
               },
               searchCharMinLimit: 1,
+              showCategoryValuesForFirstMatch: false
             },
             fields: [],
             collections: {
@@ -115,6 +116,7 @@ suite('Configuration Adapter', ({ expect, stub }) => {
                 values: []
               },
               searchCharMinLimit: 1,
+              showCategoryValuesForFirstMatch: false
             },
             fields,
             collections: {

--- a/test/unit/core/reducers/data/autocomplete.ts
+++ b/test/unit/core/reducers/data/autocomplete.ts
@@ -5,11 +5,13 @@ import suite from '../../../_suite';
 suite('autocomplete', ({ expect }) => {
   const query = 'brown shoes';
   const category = { field: 'a', values: ['b'] };
+  const showCategoryValuesForFirstMatch = false;
   const suggestions = [{ value: 'e' }, { value: 'f' }, { value: 'g' }];
   const navigations = [];
   const products = [];
   const state: Store.Autocomplete = {
     category,
+    showCategoryValuesForFirstMatch,
     products,
     navigations,
     suggestions,
@@ -20,6 +22,7 @@ suite('autocomplete', ({ expect }) => {
       const payload = 'red shoes';
       const newState = {
         category,
+        showCategoryValuesForFirstMatch: false,
         products,
         query: payload,
         navigations,
@@ -35,6 +38,7 @@ suite('autocomplete', ({ expect }) => {
       const categoryValues = ['a', 'c', 'd'];
       const newState = {
         category: { ...category, values: categoryValues },
+        showCategoryValuesForFirstMatch: false,
         products,
         navigations,
         suggestions,
@@ -56,6 +60,7 @@ suite('autocomplete', ({ expect }) => {
       const newProducts = [1, 2, 3];
       const newState = {
         category,
+        showCategoryValuesForFirstMatch: false,
         products: newProducts,
         navigations,
         suggestions,
@@ -73,6 +78,7 @@ suite('autocomplete', ({ expect }) => {
       const newTemplate = { a: 'b' };
       const newState = {
         category,
+        showCategoryValuesForFirstMatch: false,
         products,
         template: newTemplate,
         navigations,

--- a/test/unit/core/sagas/autocomplete.ts
+++ b/test/unit/core/sagas/autocomplete.ts
@@ -81,7 +81,7 @@ suite('autocomplete saga', ({ expect, spy, stub }) => {
         expect(task.next([response, trendingResponse]).value).to.eql(trendingBodyPromise);
         expect(task.next(trendingResponseValue).value).to.eql(effects.put(receiveAutocompleteSuggestionsAction));
         expect(extractAutocompleteNavigationLabels).to.be.calledWithExactly(config);
-        expect(extractSuggestions).to.be.calledWithExactly(response, query, field, navigationLabels);
+        expect(extractSuggestions).to.be.calledWithExactly(response, query, field, navigationLabels, config);
         expect(mergeSuggestions).to.be.calledWithExactly(suggestions.suggestions, trendingResponseValue);
         // tslint:disable-next-line max-line-length
         expect(receiveAutocompleteSuggestions).to.be.calledWithExactly({ ...suggestions, suggestions: mergedSuggestions });


### PR DESCRIPTION
added a `showCategoryValuesForFirstMatch` flag to `autocomplete` config
this flag enables the display of autocomplete suggestions for a category pulled from the first suggested search; e.g. when the user types "lipst" autocomplete will pull from category "lipstick" as that's the first suggested term.