### PR TITLE
feat(SF-1026): Add option to always use the default collection on search

### DIFF
--- a/src/core/actions/creators.ts
+++ b/src/core/actions/creators.ts
@@ -277,11 +277,17 @@ namespace ActionCreators {
    * @return {[type]}       - Actions with relevant data.
    */
   export function search(query?: string) {
-    return (state: Store.State): Actions.Search => <any>[
-      ActionCreators.resetPage(),
-      ...ActionCreators.resetRefinements(true),
-      ...ActionCreators.updateQuery(query || Selectors.query(state))
-    ];
+    return (state: Store.State): Actions.Search => {
+
+      if ()
+
+      return <any>[
+        ActionCreators.resetPage(),
+        ...ActionCreators.resetRefinements(true),
+        ...ActionCreators.selectCollection(),
+        ...ActionCreators.updateQuery(query || Selectors.query(state))
+      ]
+    };
   }
 
   /**

--- a/src/core/actions/creators.ts
+++ b/src/core/actions/creators.ts
@@ -278,15 +278,14 @@ namespace ActionCreators {
    */
   export function search(query?: string) {
     return (state: Store.State): Actions.Search => {
+      const actions: any = [ActionCreators.resetPage()];
+      if (Selectors.config(state).search.useDefaultCollection) {
+        actions.push(ActionCreators.selectCollection(Selectors.defaultCollection(state)));
+      }
+      // tslint:disable-next-line max-line-length
+      actions.push(...ActionCreators.resetRefinements(true), ...ActionCreators.updateQuery(query || Selectors.query(state)));
 
-      if ()
-
-      return <any>[
-        ActionCreators.resetPage(),
-        ...ActionCreators.resetRefinements(true),
-        ...ActionCreators.selectCollection(),
-        ...ActionCreators.updateQuery(query || Selectors.query(state))
-      ]
+      return actions;
     };
   }
 

--- a/src/core/actions/index.ts
+++ b/src/core/actions/index.ts
@@ -70,9 +70,10 @@ namespace Actions {
 
   // batch actions
   export type SwitchRefinement = [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.AddRefinement];
-  export type Search = [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.AddRefinement];
-  export type ResetRecall = [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.UpdateQuery] |
-    [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.UpdateQuery, Actions.ResetPage, Actions.SelectRefinement];
+  export type Search = [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.AddRefinement]
+    | [Actions.ResetPage, Actions.SelectCollection, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.AddRefinement];
+  export type ResetRecall = [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.UpdateQuery]
+    | [Actions.ResetPage, Actions.ResetPage, Actions.ResetRefinements, Actions.ResetPage, Actions.UpdateQuery, Actions.ResetPage, Actions.SelectRefinement];
   export type UpdateSearch = Array<Actions.ResetPage | Actions.UpdateQuery | Actions.ResetRefinements | Actions.SelectRefinement | Actions.AddRefinement>;
   export type ResetPageAndResetRefinements = [Actions.ResetPage, Actions.ResetRefinements];
   export type ResetPageAndSelectRefinement = [Actions.ResetPage, Actions.SelectRefinement];

--- a/src/core/configuration.ts
+++ b/src/core/configuration.ts
@@ -118,11 +118,14 @@ namespace Configuration {
      * redirect to the details page of product if there is only 1 product result for a search
      */
     redirectSingleResult: boolean;
-
     /**
      * maximum number of refinements to show in a single section
      */
     maxRefinements?: number;
+    /**
+     * reset the collection to the default collection on a search
+     */
+    useDefaultCollection?: boolean;
     /**
      * default request values
      */

--- a/src/core/selectors.ts
+++ b/src/core/selectors.ts
@@ -47,6 +47,14 @@ namespace Selectors {
   };
 
   /**
+   * Returns the name of the default collection
+   */
+  export const defaultCollection = (state: Store.State) => {
+    const collectionConfig = Selectors.config(state).collection;
+    return typeof collectionConfig === 'string' ? collectionConfig : collectionConfig.default;
+  };
+
+  /**
    * Returns the collections object.
    */
   export const collections = (state: Store.State) =>

--- a/test/unit/core/actions/creators.ts
+++ b/test/unit/core/actions/creators.ts
@@ -476,6 +476,33 @@ suite('ActionCreators', ({ expect, spy, stub }) => {
         expect(resetRefinements).to.be.calledWithExactly(true);
         expect(updateQuery).to.be.calledWithExactly(query);
       });
+
+      it.only('should switch to the default collection if set in the config', () => {
+        const query = 'pineapple';
+
+        const resetRefinementsReturn = 'reset';
+        const updateReturn = 'update';
+        const resetPageReturn = 'page';
+        const selectCollectionReturn = 'collection';
+
+        const resetRefinements = stub(ActionCreators, 'resetRefinements').returns(resetRefinementsReturn);
+        const updateQuery = stub(ActionCreators, 'updateQuery').returns(updateReturn);
+        const selectCollection = stub(ActionCreators, 'selectCollection').returns(selectCollectionReturn);
+        stub(ActionCreators, 'resetPage').returns(resetPageReturn);
+
+        const result = ActionCreators.search(query)(null);
+        console.log('DEBUG Result', result);
+
+        expect(result).to.eql([
+          resetPageReturn,
+          resetRefinementsReturn,
+          selectCollectionReturn,
+          updateReturn,
+        ]);
+        expect(resetRefinements).to.be.calledWithExactly(true);
+        expect(selectCollection).to.be.calledWithExactly();
+        expect(updateQuery).to.be.calledWithExactly(query);
+      });
     });
 
     describe('resetRecall()', () => {

--- a/test/unit/core/actions/creators.ts
+++ b/test/unit/core/actions/creators.ts
@@ -434,21 +434,20 @@ suite('ActionCreators', ({ expect, spy, stub }) => {
     describe('search()', () => {
       it('should call ActionCreators.updateSearch()', () => {
         const query = 'pineapple';
-
-        const resetRefinementsReturn = 'reset';
-        const updateReturn = 'update';
+        const resetRefinementsReturn = ['reset'];
+        const updateReturn = ['update'];
         const resetPageReturn = 'page';
-
         const resetRefinements = stub(ActionCreators, 'resetRefinements').returns(resetRefinementsReturn);
         const updateQuery = stub(ActionCreators, 'updateQuery').returns(updateReturn);
         stub(ActionCreators, 'resetPage').returns(resetPageReturn);
+        stub(Selectors, 'config').returns({ search: { useDefaultCollection: false } });
 
         const result = ActionCreators.search(query)(null);
 
         expect(result).to.eql([
           resetPageReturn,
-          resetRefinementsReturn,
-          updateReturn,
+          ...resetRefinementsReturn,
+          ...updateReturn,
         ]);
         expect(resetRefinements).to.be.calledWithExactly(true);
         expect(updateQuery).to.be.calledWithExactly(query);
@@ -456,51 +455,50 @@ suite('ActionCreators', ({ expect, spy, stub }) => {
 
       it('should fall back to current query', () => {
         const query = 'pineapple';
-
-        const resetRefinementsReturn = 'reset';
-        const updateReturn = 'update';
+        const resetRefinementsReturn = ['reset'];
+        const updateReturn = ['update'];
         const resetPageReturn = 'page';
-
         const resetRefinements = stub(ActionCreators, 'resetRefinements').returns(resetRefinementsReturn);
         const updateQuery = stub(ActionCreators, 'updateQuery').returns(updateReturn);
         const queryStub = stub(Selectors, 'query').returns(query);
         stub(ActionCreators, 'resetPage').returns(resetPageReturn);
+        stub(Selectors, 'config').returns({ search: { useDefaultCollection: false } });
 
         const result = ActionCreators.search()(null);
 
         expect(result).to.eql([
           resetPageReturn,
-          resetRefinementsReturn,
-          updateReturn,
+          ...resetRefinementsReturn,
+          ...updateReturn,
         ]);
         expect(resetRefinements).to.be.calledWithExactly(true);
         expect(updateQuery).to.be.calledWithExactly(query);
       });
 
-      it.only('should switch to the default collection if set in the config', () => {
+      it('should switch to the default collection if set in the config', () => {
         const query = 'pineapple';
-
-        const resetRefinementsReturn = 'reset';
-        const updateReturn = 'update';
+        const resetRefinementsReturn = ['reset'];
+        const updateReturn = ['update'];
         const resetPageReturn = 'page';
         const selectCollectionReturn = 'collection';
-
+        const defaultCollection = 'defaultCollection';
+        const config = stub(Selectors, 'config').returns({ search: { useDefaultCollection: true } });
+        const selectCollection = stub(ActionCreators, 'selectCollection').returns(selectCollectionReturn);
         const resetRefinements = stub(ActionCreators, 'resetRefinements').returns(resetRefinementsReturn);
         const updateQuery = stub(ActionCreators, 'updateQuery').returns(updateReturn);
-        const selectCollection = stub(ActionCreators, 'selectCollection').returns(selectCollectionReturn);
         stub(ActionCreators, 'resetPage').returns(resetPageReturn);
+        stub(Selectors, 'defaultCollection').returns(defaultCollection);
 
         const result = ActionCreators.search(query)(null);
-        console.log('DEBUG Result', result);
 
         expect(result).to.eql([
           resetPageReturn,
-          resetRefinementsReturn,
           selectCollectionReturn,
-          updateReturn,
+          ...resetRefinementsReturn,
+          ...updateReturn,
         ]);
         expect(resetRefinements).to.be.calledWithExactly(true);
-        expect(selectCollection).to.be.calledWithExactly();
+        expect(selectCollection).to.be.calledWithExactly(defaultCollection);
         expect(updateQuery).to.be.calledWithExactly(query);
       });
     });

--- a/test/unit/core/selectors.ts
+++ b/test/unit/core/selectors.ts
@@ -178,6 +178,26 @@ suite('selectors', ({ expect, stub }) => {
     });
   });
 
+  describe('defaultCollection()', () => {
+    it('should return the default collection from object', () => {
+      const defaultCollection = 'defaultCollection';
+      const state: any = { a: 'b' };
+      const config = stub(Selectors, 'config').returns({ collection: { default: defaultCollection } });
+
+      expect(Selectors.defaultCollection(state)).to.eq(defaultCollection);
+      expect(config).to.be.calledWith(state);
+    });
+
+    it('should return the default collection from string', () => {
+      const defaultCollection = 'defaultCollection';
+      const state: any = { a: 'b' };
+      const config = stub(Selectors, 'config').returns({ collection: defaultCollection });
+
+      expect(Selectors.defaultCollection(state)).to.eq(defaultCollection);
+      expect(config).to.be.calledWith(state);
+    });
+  });
+
   describe('collections()', () => {
     it('should return indexed collections data', () => {
       const collections = { a: 'b' };


### PR DESCRIPTION
Set the configuration option `search.useDefaultCollection` to `true` to always search against the default collection, or `false` to search against the current selected collection. The default is `false`.