### PR TITLE
fix(SF-1036): Lock down redux-persist version

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "groupby-api": "2.5.0",
     "redux": "^3.7.0",
     "redux-logger": "^3.0.6",
-    "redux-persist": "^5.1.0",
+    "redux-persist": "5.4.0",
     "redux-saga": "^0.16.0",
     "redux-undo": "^0.6.1",
     "redux-validator": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3144,9 +3144,9 @@ redux-logger@^3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
-redux-persist@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.1.0.tgz#38f43fe7a3e0dad7e3240c00f737ccd2682b6cd9"
+redux-persist@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.4.0.tgz#a1062313546a9d4ca6f9271464d18f736e8ca394"
 
 redux-saga@^0.16.0:
   version "0.16.0"


### PR DESCRIPTION
Because there have been api updates in `5.10.0` which cause our code to break