### PR TITLE
fix(SF-1083): Do not impose query restrictions on searches

### DIFF
--- a/src/core/actions/creators.ts
+++ b/src/core/actions/creators.ts
@@ -317,10 +317,7 @@ namespace ActionCreators {
     return [
       ActionCreators.resetPage(),
       createAction(Actions.UPDATE_QUERY, query && query.trim(), {
-        payload: [
-          validators.isValidQuery,
-          validators.isDifferentQuery
-        ]
+        payload: validators.isValidQuery,
       })
     ];
   }

--- a/src/core/actions/validators.ts
+++ b/src/core/actions/validators.ts
@@ -18,11 +18,6 @@ export const isValidQuery: Validator<string> = {
   msg: 'search term is empty'
 };
 
-export const isDifferentQuery: Validator<string> = {
-  func: (query, state) => query !== Selectors.query(state),
-  msg: 'search term is not different'
-};
-
 export const isRangeRefinement: Validator<Actions.Payload.Navigation.AddRefinement> = {
   func: ({ range, low, high }) => !range || (typeof low === 'number' && typeof high === 'number'),
   msg: 'low and high values must be numeric'

--- a/test/unit/core/actions/creators.ts
+++ b/test/unit/core/actions/creators.ts
@@ -362,10 +362,7 @@ suite('ActionCreators', ({ expect, spy, stub }) => {
 
       it('should apply validators to UPDATE_QUERY', () => {
         expectValidators(ActionCreators.updateQuery(query), Actions.UPDATE_QUERY, {
-          payload: [
-            validators.isValidQuery,
-            validators.isDifferentQuery
-          ]
+          payload: validators.isValidQuery,
         });
       });
     });

--- a/test/unit/core/actions/validators.ts
+++ b/test/unit/core/actions/validators.ts
@@ -32,22 +32,6 @@ suite('validators', ({ expect, spy, stub }) => {
     });
   });
 
-  describe('isDifferentQuery', () => {
-    const query = 'rambo';
-
-    it('should be valid if query will change', () => {
-      stub(Selectors, 'query').returns('shark');
-
-      expect(validators.isDifferentQuery.func(query)).to.be.true;
-    });
-
-    it('should be invalid if query will not change', () => {
-      stub(Selectors, 'query').returns(query);
-
-      expect(validators.isDifferentQuery.func(query)).to.be.false;
-    });
-  });
-
   describe('isValidClearField', () => {
     it('should use isString validator', () => {
       const field = 'brand';


### PR DESCRIPTION
Checking to see if the search is empty or different is business logic that may or may not be desired. Lift these restrictions so that repeat queries and empty queries can be sent.