### PR TITLE
fix(SF-1129): Don't override refinements for pastPurchases

### DIFF
--- a/src/core/sagas/recommendations.ts
+++ b/src/core/sagas/recommendations.ts
@@ -118,7 +118,6 @@ export namespace Tasks {
         const pastPurchasesFromSkus = Tasks.buildRequestFromSkus(flux, pastPurchaseSkus);
         const request = pastPurchaseProductsRequest.composeRequest(state, {
           query: '',
-          refinements: [],
           ...pastPurchasesFromSkus,
           ...action.payload.request
         });

--- a/test/unit/core/sagas/recommendations.ts
+++ b/test/unit/core/sagas/recommendations.ts
@@ -292,7 +292,6 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         task.next(state);
         expect(composeRequest).to.be.calledWith(state, {
           query: '',
-          refinements: [],
           ...pastPurchaseFromSkus,
           ...override
         });
@@ -342,7 +341,6 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         stub(RequestBuilders.pastPurchaseProductsRequest, 'composeRequest')
           .withArgs(state, {
             query: '',
-            refinements: [],
             ...pastPurchasesFromSkus,
           })
           .returns(request);
@@ -392,7 +390,6 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         stub(RequestBuilders.pastPurchaseProductsRequest, 'composeRequest')
           .withArgs(state, {
             query: '',
-            refinements: [],
             ...pastPurchasesFromSkus,
           })
           .returns(request);


### PR DESCRIPTION
Refinements are no longer being set to an empty array within fetchPastPurchasedProducts function.