### PR TITLE
feat(SF-1146): Add `pastPurchases` and `recommendations` overrides

### DIFF
--- a/src/core/adapters/configuration.ts
+++ b/src/core/adapters/configuration.ts
@@ -1,5 +1,6 @@
 import { Request } from 'groupby-api';
 import { AutocompleteConfig, ProductSearchConfig } from 'sayt';
+import Recommendations from '../adapters/recommendations';
 import Configuration from '../configuration';
 import * as AreaReducer from '../reducers/data/area';
 import * as AutocompleteReducer from '../reducers/data/autocomplete';
@@ -201,6 +202,24 @@ namespace Adapter {
 
   export const refinementsOverrides: Override<Request> = (config) =>
     normalizeToFunction(config.refinements.overrides);
+
+  export const pastPurchaseAutocompleteOverrides: Override<Request> = (config) =>
+    normalizeToFunction(config.recommendations.pastPurchases.overrides.autocomplete);
+
+  export const pastPurchaseOverrides: Override<Request> = (config) =>
+    normalizeToFunction(config.recommendations.pastPurchases.overrides.products);
+
+  export const recommendationsNavigationsOverrides: Override<Recommendations.RecommendationsBody> = (config) =>
+    normalizeToFunction(config.recommendations.overrides.navigations);
+
+  export const recommendationsIdsOverrides: Override<Recommendations.RecommendationsRequest> = (config) =>
+    normalizeToFunction(config.recommendations.overrides.ids);
+
+  export const recommendationsProductsOverrides: Override<Request> = (config) =>
+    normalizeToFunction(config.recommendations.overrides.products);
+
+  export const recommendationsSuggestionsOverrides: Override<Recommendations.Request & { query: string }> = (config) =>
+    normalizeToFunction(config.recommendations.overrides.autocompleteSuggestions);
 }
 
 export default Adapter;

--- a/src/core/configuration.ts
+++ b/src/core/configuration.ts
@@ -1,5 +1,6 @@
 import { BiasStrength, BrowserBridge, Request } from 'groupby-api';
 import { QueryTimeAutocompleteConfig, QueryTimeProductSearchConfig, Sayt } from 'sayt';
+import RecommendationsAdapter from './adapters/recommendations';
 
 interface Configuration {
   /**
@@ -215,7 +216,7 @@ namespace Configuration {
 
   // tslint:disable:max-line-length
   export type AutocompleteSuggestionsOverrides = Partial<QueryTimeAutocompleteConfig> | ((currConfig: QueryTimeAutocompleteConfig, prevConfig: QueryTimeAutocompleteConfig) => QueryTimeAutocompleteConfig);
-  export type AutocompleteProductsOverrides = Partial<QueryTimeProductSearchConfig> | ((currConfig: QueryTimeProductSearchConfig, prevConfig?: QueryTimeProductSearchConfig) => QueryTimeProductSearchConfig);
+  export type AutocompleteProductsOverrides = Partial<QueryTimeProductSearchConfig> | ((currConfig: QueryTimeProductSearchConfig, prevConfig: QueryTimeProductSearchConfig) => QueryTimeProductSearchConfig);
   // tslint:enable:max-line-length
 
   export namespace Autocomplete {
@@ -263,7 +264,23 @@ namespace Configuration {
     productSuggestions: Configuration.Recommendations.ProductSuggestions;
     iNav: Configuration.Recommendations.INav;
     pastPurchases: Configuration.Recommendations.PastPurchases;
+
+    /**
+     * override any computed request value
+     */
+    overrides?: {
+      navigations?: Configuration.RecommendationsNavigationsOverrides;
+      ids?: Configuration.RecommendationsIdsOverrides;
+      products?: Configuration.SearchOverrides;
+      autocompleteSuggestions?: Configuration.RecommendationsSuggestionsOverrides;
+    };
   }
+
+  // tslint:disable:max-line-length
+  export type RecommendationsNavigationsOverrides = Partial<RecommendationsAdapter.RecommendationsBody> | ((currReq: RecommendationsAdapter.RecommendationsBody, prevReq: RecommendationsAdapter.RecommendationsBody) => RecommendationsAdapter.RecommendationsBody);
+  export type RecommendationsIdsOverrides = Partial<RecommendationsAdapter.RecommendationsRequest> | ((currReq: RecommendationsAdapter.RecommendationsRequest, prevReq: RecommendationsAdapter.RecommendationsRequest) => RecommendationsAdapter.RecommendationsRequest);
+  export type RecommendationsSuggestionsOverrides = Partial<RecommendationsAdapter.Request & { query: string }> | ((currReq: RecommendationsAdapter.Request & { query: string }, prevReq: RecommendationsAdapter.Request & { query: string }) => RecommendationsAdapter.Request & { query: string });
+  // tslint:enable:max-line-length
 
   export interface Personalization {
     realTimeBiasing?: Personalization.RealTimeBiasing;
@@ -316,6 +333,14 @@ namespace Configuration {
        * Enable past purchases or not
        */
       enabled: boolean;
+
+      /**
+       * override any computed request value
+       */
+      overrides?: {
+        autocomplete?: Configuration.SearchOverrides;
+        products?: Configuration.SearchOverrides;
+      };
     }
 
     export interface SecuredPayload {

--- a/src/core/requests/index.ts
+++ b/src/core/requests/index.ts
@@ -41,14 +41,14 @@ export default class RequestBuilder<T = any, U = T> {
 /* tslint:disable max-line-length */
 export const autocompleteProductsRequest = new RequestBuilder<Request>(RequestHelpers.autocompleteProducts, Configuration.autocompleteProductsOverrides);
 export const autocompleteSuggestionsRequest = new RequestBuilder<QueryTimeAutocompleteConfig>(RequestHelpers.autocompleteSuggestions, Configuration.autocompleteSuggestionsOverrides);
-export const autocompletePastPurchaseRequest = new RequestBuilder<Request>(RequestHelpers.autocompleteProducts);
+export const autocompletePastPurchaseRequest = new RequestBuilder<Request>(RequestHelpers.autocompleteProducts, Configuration.pastPurchaseAutocompleteOverrides);
 export const collectionRequest = new RequestBuilder<Request>(RequestHelpers.search, Configuration.collectionOverrides);
-export const pastPurchaseProductsRequest = new RequestBuilder<Request>(RequestHelpers.pastPurchaseProducts);
+export const pastPurchaseProductsRequest = new RequestBuilder<Request>(RequestHelpers.pastPurchaseProducts, Configuration.pastPurchaseOverrides);
 export const productDetailsRequest = new RequestBuilder<Request>(RequestHelpers.search, Configuration.detailsOverrides);
 export const productsRequest = new RequestBuilder<Request>(RequestHelpers.products, Configuration.searchOverrides);
-export const recommendationsNavigationsRequest = new RequestBuilder<Recommendations.RecommendationsBody>(RequestHelpers.recommendationsNavigations);
-export const recommendationsProductIdsRequest = new RequestBuilder<Recommendations.RecommendationsRequest>(RequestHelpers.recommendationsProductIDs);
-export const recommendationsProductsRequest = new RequestBuilder<Request>(RequestHelpers.search);
-export const recommendationsSuggestionsRequest = new RequestBuilder<Recommendations.Request & { query: string }, Recommendations.Request>(RequestHelpers.recommendationsSuggestions);
+export const recommendationsNavigationsRequest = new RequestBuilder<Recommendations.RecommendationsBody>(RequestHelpers.recommendationsNavigations, Configuration.recommendationsNavigationsOverrides);
+export const recommendationsProductIdsRequest = new RequestBuilder<Recommendations.RecommendationsRequest>(RequestHelpers.recommendationsProductIDs, Configuration.recommendationsIdsOverrides);
+export const recommendationsProductsRequest = new RequestBuilder<Request>(RequestHelpers.search, Configuration.recommendationsProductsOverrides);
+export const recommendationsSuggestionsRequest = new RequestBuilder<Recommendations.Request & { query: string }, Recommendations.Request>(RequestHelpers.recommendationsSuggestions, Configuration.recommendationsSuggestionsOverrides);
 export const refinementsRequest = new RequestBuilder<Request>(RequestHelpers.search, Configuration.refinementsOverrides);
 /* tslint:enable */

--- a/test/unit/core/adapters/configuration.ts
+++ b/test/unit/core/adapters/configuration.ts
@@ -467,6 +467,17 @@ suite('Configuration Adapter', ({ expect, stub }) => {
 
       expect(Adapter.searchOverrides(state)(o)).to.eql({ ...o, ...overrides });
     });
+
+    it('should return a normalized function', () => {
+      const overrides = { a: 'b' };
+      const config: any = {
+        search: {
+          overrides
+        }
+      };
+
+      expect(Adapter.searchOverrides(config)(<any>{})).to.eql(overrides);
+    });
   });
 
   describe('autocompleteSuggestionsOverrides()', () => {
@@ -482,6 +493,19 @@ suite('Configuration Adapter', ({ expect, stub }) => {
       const o: any = { c: 'd' };
 
       expect(Adapter.autocompleteSuggestionsOverrides(state)(o)).to.eql({ ...o, ...suggestions });
+    });
+
+    it('should return a normalized function', () => {
+      const overrides = { c: 'd' };
+      const config: any = {
+        autocomplete: {
+          overrides: {
+            suggestions: overrides
+          }
+        }
+      };
+
+      expect(Adapter.autocompleteSuggestionsOverrides(config)(<any>{})).to.eql(overrides);
     });
   });
 
@@ -499,37 +523,7 @@ suite('Configuration Adapter', ({ expect, stub }) => {
 
       expect(Adapter.autocompleteProductsOverrides(state)(o)).to.eql({ ...o, ...products });
     });
-  });
 
-  describe('searchOverrides()', () => {
-    it('should return a normalized function', () => {
-      const overrides = { a: 'b' };
-      const config: any = {
-        search: {
-          overrides
-        }
-      };
-
-      expect(Adapter.searchOverrides(config)(<any>{})).to.eql(overrides);
-    });
-  });
-
-  describe('autocompleteSuggestionsOverrides()', () => {
-    it('should return a normalized function', () => {
-      const overrides = { c: 'd' };
-      const config: any = {
-        autocomplete: {
-          overrides: {
-            suggestions: overrides
-          }
-        }
-      };
-
-      expect(Adapter.autocompleteSuggestionsOverrides(config)(<any>{})).to.eql(overrides);
-    });
-  });
-
-  describe('autocompleteProductsOverrides()', () => {
     it('should return a normalized function', () => {
       const overrides = { a: 'b' };
       const config: any = {
@@ -545,6 +539,20 @@ suite('Configuration Adapter', ({ expect, stub }) => {
   });
 
   describe('collectionOverrides()', () => {
+    it('should return the collections overrides function', () => {
+      const state: any = { collections: { overrides: (r) => r } };
+
+      expect(Adapter.collectionOverrides(state)).to.eq(state.collections.overrides);
+    });
+
+    it('should return a function that mixes in the overrides with a given object', () => {
+      const overrides: any = { a: 'b' };
+      const state: any = { collections: { overrides } };
+      const o: any = { c: 'd' };
+
+      expect(Adapter.collectionOverrides(state)(o)).to.eql({ ...o, ...overrides });
+    });
+
     it('should return a normalized function', () => {
       const overrides = { a: 'b' };
       const config: any = {
@@ -558,6 +566,20 @@ suite('Configuration Adapter', ({ expect, stub }) => {
   });
 
   describe('detailsOverrides()', () => {
+    it('should return the details overrides function', () => {
+      const state: any = { details: { overrides: (r) => r } };
+
+      expect(Adapter.detailsOverrides(state)).to.eq(state.details.overrides);
+    });
+
+    it('should return a function that mixes in the overrides with a given object', () => {
+      const overrides: any = { a: 'b' };
+      const state: any = { details: { overrides } };
+      const o: any = { c: 'd' };
+
+      expect(Adapter.detailsOverrides(state)(o)).to.eql({ ...o, ...overrides });
+    });
+
     it('should return a normalized function', () => {
       const overrides = { a: 'b' };
       const config: any = {
@@ -571,6 +593,20 @@ suite('Configuration Adapter', ({ expect, stub }) => {
   });
 
   describe('refinementsOverrides', () => {
+    it('should return the refinements overrides function', () => {
+      const state: any = { refinements: { overrides: (r) => r } };
+
+      expect(Adapter.refinementsOverrides(state)).to.eq(state.refinements.overrides);
+    });
+
+    it('should return a function that mixes in the overrides with a given object', () => {
+      const overrides: any = { a: 'b' };
+      const state: any = { refinements: { overrides } };
+      const o: any = { c: 'd' };
+
+      expect(Adapter.refinementsOverrides(state)(o)).to.eql({ ...o, ...overrides });
+    });
+
     it('should return a normalized function', () => {
       const overrides = { a: 'b' };
       const config: any = {
@@ -583,7 +619,53 @@ suite('Configuration Adapter', ({ expect, stub }) => {
     });
   });
 
+  describe('pastPurchaseAutocompleteOverrides', () => {
+    it('should return the pastPurchases autocomplete overrides function', () => {
+      const state: any = { recommendations: { pastPurchases: { overrides: { autocomplete: (r) => r } } } };
+
+      expect(Adapter.pastPurchaseAutocompleteOverrides(state))
+        .to.eq(state.recommendations.pastPurchases.overrides.autocomplete);
+    });
+
+    it('should return a function that mixes in the overrides with a given object', () => {
+      const overrides: any = { a: 'b' };
+      const state: any = { recommendations: { pastPurchases: { overrides: { autocomplete: overrides } } } };
+      const o: any = { c: 'd' };
+
+      expect(Adapter.pastPurchaseAutocompleteOverrides(state)(o)).to.eql({ ...o, ...overrides });
+    });
+
+    it('should return a normalized function', () => {
+      const overrides = { a: 'b' };
+      const config: any = {
+        recommendations: {
+          pastPurchases: {
+            overrides: {
+              autocomplete: overrides
+            }
+          }
+        }
+      };
+
+      expect(Adapter.pastPurchaseAutocompleteOverrides(config)(<any>{})).to.eql(overrides);
+    });
+  });
+
   describe('pastPurchaseOverrides', () => {
+    it('should return the pastPurchases products overrides function', () => {
+      const state: any = { recommendations: { pastPurchases: { overrides: { products: (r) => r } } } };
+
+      expect(Adapter.pastPurchaseOverrides(state)).to.eq(state.recommendations.pastPurchases.overrides.products);
+    });
+
+    it('should return a function that mixes in the overrides with a given object', () => {
+      const overrides: any = { a: 'b' };
+      const state: any = { recommendations: { pastPurchases: { overrides: { products: overrides } } } };
+      const o: any = { c: 'd' };
+
+      expect(Adapter.pastPurchaseOverrides(state)(o)).to.eql({ ...o, ...overrides });
+    });
+
     it('should return a normalized function', () => {
       const overrides = { a: 'b' };
       const config: any = {
@@ -601,6 +683,21 @@ suite('Configuration Adapter', ({ expect, stub }) => {
   });
 
   describe('recommendationsNavigationsOverrides', () => {
+    it('should return the recommendations navigations overrides function', () => {
+      const state: any = { recommendations: { overrides: { navigations: (r) => r } } };
+
+      expect(Adapter.recommendationsNavigationsOverrides(state))
+        .to.eq(state.recommendations.overrides.navigations);
+    });
+
+    it('should return a function that mixes in the overrides with a given object', () => {
+      const overrides: any = { a: 'b' };
+      const state: any = { recommendations: { overrides: { navigations: overrides } } };
+      const o: any = { c: 'd' };
+
+      expect(Adapter.recommendationsNavigationsOverrides(state)(o)).to.eql({ ...o, ...overrides });
+    });
+
     it('should return a normalized function', () => {
       const overrides = { a: 'b' };
       const config: any = {
@@ -616,6 +713,21 @@ suite('Configuration Adapter', ({ expect, stub }) => {
   });
 
   describe('recommendationsIdsOverrides', () => {
+    it('should return the recommendations ids overrides function', () => {
+      const state: any = { recommendations: { overrides: { ids: (r) => r } } };
+
+      expect(Adapter.recommendationsIdsOverrides(state))
+        .to.eq(state.recommendations.overrides.ids);
+    });
+
+    it('should return a function that mixes in the overrides with a given object', () => {
+      const overrides: any = { a: 'b' };
+      const state: any = { recommendations: { overrides: { ids: overrides } } };
+      const o: any = { c: 'd' };
+
+      expect(Adapter.recommendationsIdsOverrides(state)(o)).to.eql({ ...o, ...overrides });
+    });
+
     it('should return a normalized function', () => {
       const overrides = { a: 'b' };
       const config: any = {
@@ -631,6 +743,21 @@ suite('Configuration Adapter', ({ expect, stub }) => {
   });
 
   describe('recommendationsProductsOverrides', () => {
+    it('should return the recommendations products overrides function', () => {
+      const state: any = { recommendations: { overrides: { products: (r) => r } } };
+
+      expect(Adapter.recommendationsProductsOverrides(state))
+        .to.eq(state.recommendations.overrides.products);
+    });
+
+    it('should return a function that mixes in the overrides with a given object', () => {
+      const overrides: any = { a: 'b' };
+      const state: any = { recommendations: { overrides: { products: overrides } } };
+      const o: any = { c: 'd' };
+
+      expect(Adapter.recommendationsProductsOverrides(state)(o)).to.eql({ ...o, ...overrides });
+    });
+
     it('should return a normalized function', () => {
       const overrides = { a: 'b' };
       const config: any = {
@@ -646,6 +773,21 @@ suite('Configuration Adapter', ({ expect, stub }) => {
   });
 
   describe('recommendationsSuggestionsOverrides', () => {
+    it('should return the recommendations autocompleteSuggestions overrides function', () => {
+      const state: any = { recommendations: { overrides: { autocompleteSuggestions: (r) => r } } };
+
+      expect(Adapter.recommendationsSuggestionsOverrides(state))
+        .to.eq(state.recommendations.overrides.autocompleteSuggestions);
+    });
+
+    it('should return a function that mixes in the overrides with a given object', () => {
+      const overrides: any = { a: 'b' };
+      const state: any = { recommendations: { overrides: { autocompleteSuggestions: overrides } } };
+      const o: any = { c: 'd' };
+
+      expect(Adapter.recommendationsSuggestionsOverrides(state)(o)).to.eql({ ...o, ...overrides });
+    });
+
     it('should return a normalized function', () => {
       const overrides = { a: 'b' };
       const config: any = {

--- a/test/unit/core/adapters/configuration.ts
+++ b/test/unit/core/adapters/configuration.ts
@@ -582,4 +582,81 @@ suite('Configuration Adapter', ({ expect, stub }) => {
       expect(Adapter.refinementsOverrides(config)(<any>{})).to.eql(overrides);
     });
   });
+
+  describe('pastPurchaseOverrides', () => {
+    it('should return a normalized function', () => {
+      const overrides = { a: 'b' };
+      const config: any = {
+        recommendations: {
+          pastPurchases: {
+            overrides: {
+              products: overrides
+            }
+          }
+        }
+      };
+
+      expect(Adapter.pastPurchaseOverrides(config)(<any>{})).to.eql(overrides);
+    });
+  });
+
+  describe('recommendationsNavigationsOverrides', () => {
+    it('should return a normalized function', () => {
+      const overrides = { a: 'b' };
+      const config: any = {
+        recommendations: {
+          overrides: {
+            navigations: overrides
+          }
+        }
+      };
+
+      expect(Adapter.recommendationsNavigationsOverrides(config)(<any>{})).to.eql(overrides);
+    });
+  });
+
+  describe('recommendationsIdsOverrides', () => {
+    it('should return a normalized function', () => {
+      const overrides = { a: 'b' };
+      const config: any = {
+        recommendations: {
+          overrides: {
+            ids: overrides
+          }
+        }
+      };
+
+      expect(Adapter.recommendationsIdsOverrides(config)(<any>{})).to.eql(overrides);
+    });
+  });
+
+  describe('recommendationsProductsOverrides', () => {
+    it('should return a normalized function', () => {
+      const overrides = { a: 'b' };
+      const config: any = {
+        recommendations: {
+          overrides: {
+            products: overrides
+          }
+        }
+      };
+
+      expect(Adapter.recommendationsProductsOverrides(config)(<any>{})).to.eql(overrides);
+    });
+  });
+
+  describe('recommendationsSuggestionsOverrides', () => {
+    it('should return a normalized function', () => {
+      const overrides = { a: 'b' };
+      const config: any = {
+        recommendations: {
+          overrides: {
+            autocompleteSuggestions: overrides
+          }
+        }
+      };
+
+      expect(Adapter.recommendationsSuggestionsOverrides(config)(<any>{})).to.eql(overrides);
+    });
+  });
 });


### PR DESCRIPTION
* Overrides accept either an object or function, like all the other overrides
* pastPurchase overrides configuration:
```
overrides: {
  autocomplete: { ... },
  products: { ... },
}
```
* recommendations overrides configuration:
```
overrides: {
  navigations: { ... },
  ids: { ... },
  products: { ... },
  autocompleteSuggstions: { ... },
}
```