### PR TITLE
chore: Remove invalid properties

### DIFF
--- a/test/unit/core/reducers/data/navigations.ts
+++ b/test/unit/core/reducers/data/navigations.ts
@@ -258,7 +258,6 @@ suite('navigations', ({ expect }) => {
           navigationId: 'Brand',
           range: false,
           value: 'Oakley',
-          clear: true
         }
       });
 
@@ -454,7 +453,6 @@ suite('navigations', ({ expect }) => {
           navigationId: 'Format',
           refinements,
           selected,
-          show: [1, 2]
         }
       });
 


### PR DESCRIPTION
This is causing the tests to fail to compile when treated as TypeScript 3.