### PR TITLE
chore(SF-1201): Mark the repo as MOVED

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# FluxCapacitor
+# [MOVED] FluxCapacitor
+
+* * *
+
+**This repository has been moved to <https://github.com/groupby/storefront>.**
+
+* * *
 
 State Management for StoreFront
 


### PR DESCRIPTION
This package, along with other StoreFront packages, have been moved to a monorepo:

https://github.com/groupby/storefront